### PR TITLE
fix issues warned by new changes in go1.10

### DIFF
--- a/httppool/breakerClient_test.go
+++ b/httppool/breakerClient_test.go
@@ -37,7 +37,7 @@ func TestDispatchWithBreaker(t *testing.T) {
 				defer wg.Done()
 
 				if resp == nil {
-					t.Error("Failed to obtain a response.  url: %v", u)
+					t.Errorf("Failed to obtain a response.  url: %v", u)
 				}
 			}
 		}(url, wg)

--- a/secure/key/resolver.go
+++ b/secure/key/resolver.go
@@ -2,6 +2,7 @@ package key
 
 import (
 	"fmt"
+
 	"github.com/Comcast/webpa-common/resource"
 )
 
@@ -31,7 +32,7 @@ type singleResolver struct {
 
 func (r *singleResolver) String() string {
 	return fmt.Sprintf(
-		"singleResolver{parser: %s, purpose: %s, loader: %s}",
+		"singleResolver{parser: %v, purpose: %v, loader: %v}",
 		r.parser,
 		r.purpose,
 		r.loader,
@@ -56,7 +57,7 @@ type multiResolver struct {
 
 func (r *multiResolver) String() string {
 	return fmt.Sprintf(
-		"multiResolver{parser: %s, purpose: %s}",
+		"multiResolver{parser: %v, purpose: %v, expander: %v}",
 		r.parser,
 		r.purpose,
 		r.expander,

--- a/secure/tools/cmd/keyserver/keyStore.go
+++ b/secure/tools/cmd/keyserver/keyStore.go
@@ -7,8 +7,9 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"github.com/Comcast/webpa-common/secure/key"
 	"log"
+
+	"github.com/Comcast/webpa-common/secure/key"
 )
 
 // KeyStore provides a single access point for a set of keys, keyed by their key identifiers
@@ -90,7 +91,7 @@ func resolveKeys(infoLogger *log.Logger, c *Configuration, privateKeys map[strin
 		if resolvedPair.HasPrivate() {
 			privateKeys[keyID] = resolvedPair.Private().(*rsa.PrivateKey)
 		} else {
-			return fmt.Errorf("The key %s did not resolve to an RSA private key")
+			return fmt.Errorf("The key %s did not resolve to an RSA private key", keyID)
 		}
 	}
 

--- a/secure/validator_test.go
+++ b/secure/validator_test.go
@@ -682,7 +682,7 @@ func TestJWTValidatorFactory(t *testing.T) {
 					}
 
 					{
-						t.Log("Two custom validate functions returning: %v, %v", firstResult, secondResult)
+						t.Logf("Two custom validate functions returning: %v, %v", firstResult, secondResult)
 						validator := record.factory.New(first, second)
 						assert.NotNil(validator)
 						mockJWS := &mockJWS{}


### PR DESCRIPTION
Fixes only include changes to warnings given while attempting to run global repo tests:
```
HQSML-152403:webpa-common junzai200$ go test -race ./...
ok      github.com/Comcast/webpa-common/concurrent      (cached)
ok      github.com/Comcast/webpa-common/conlimiter      (cached)
ok      github.com/Comcast/webpa-common/convey  (cached)
ok      github.com/Comcast/webpa-common/convey/conveyhttp       (cached)
# github.com/Comcast/webpa-common/httppool
httppool/breakerClient_test.go:40: Error call has possible formatting directive %v
# github.com/Comcast/webpa-common/secure
secure/validator_test.go:685: Log call has possible formatting directive %v
ok      github.com/Comcast/webpa-common/device  (cached)
ok      github.com/Comcast/webpa-common/device/devicehealth     (cached)
ok      github.com/Comcast/webpa-common/event   (cached)
ok      github.com/Comcast/webpa-common/hash    (cached)
ok      github.com/Comcast/webpa-common/health  (cached)
# github.com/Comcast/webpa-common/secure/key
secure/key/resolver.go:58: Sprintf call needs 2 args but has 3 args
# github.com/Comcast/webpa-common/secure/tools/cmd/keyserver
secure/tools/cmd/keyserver/keyStore.go:93: Errorf format %s reads arg #1, but call has only 0 args
FAIL    github.com/Comcast/webpa-common/httppool [build failed]
ok      github.com/Comcast/webpa-common/httppool/health (cached)
ok      github.com/Comcast/webpa-common/logging (cached)
ok      github.com/Comcast/webpa-common/logging/mocklogging     (cached)
ok      github.com/Comcast/webpa-common/middleware      (cached)
ok      github.com/Comcast/webpa-common/middleware/fanout       (cached)
ok      github.com/Comcast/webpa-common/middleware/fanout/fanouthttp    (cached)
ok      github.com/Comcast/webpa-common/resource        (cached)
FAIL    github.com/Comcast/webpa-common/secure [build failed]
ok      github.com/Comcast/webpa-common/secure/handler  (cached)
FAIL    github.com/Comcast/webpa-common/secure/key [build failed]
?       github.com/Comcast/webpa-common/secure/tools/cmd/jwt    [no test files]
ok      github.com/Comcast/webpa-common/server  (cached)
ok      github.com/Comcast/webpa-common/service (cached)
ok      github.com/Comcast/webpa-common/store   (cached)
ok      github.com/Comcast/webpa-common/tracing (cached)
ok      github.com/Comcast/webpa-common/tracing/tracinghttp     (cached)
ok      github.com/Comcast/webpa-common/transport/transporthttp (cached)
ok      github.com/Comcast/webpa-common/types   (cached)
ok      github.com/Comcast/webpa-common/webhook (cached)
ok      github.com/Comcast/webpa-common/webhook/aws     (cached)
ok      github.com/Comcast/webpa-common/wrp     (cached)
ok      github.com/Comcast/webpa-common/wrp/wrpendpoint (cached)
ok      github.com/Comcast/webpa-common/wrp/wrphttp     (cached)
ok      github.com/Comcast/webpa-common/xhttp   (cached)
ok      github.com/Comcast/webpa-common/xlistener       (cached)
ok      github.com/Comcast/webpa-common/xmetrics        (cached)
ok      github.com/Comcast/webpa-common/xmetrics/xmetricstest   (cached)```