### PR TITLE
Fix talaria multiple registrations

### DIFF
--- a/service/consul/environment.go
+++ b/service/consul/environment.go
@@ -100,19 +100,19 @@ func newInstancers(l log.Logger, c gokitconsul.Client, co Options) (i service.In
 func newRegistrars(l log.Logger, registrationScheme string, c gokitconsul.Client, u ttlUpdater, co Options) (r service.Registrars, closer func() error, err error) {
 	var consulRegistrar sd.Registrar
 	for _, registration := range co.registrations() {
-		localRegistration := registration
+		registration := registration
 
-		instance := service.FormatInstance(registrationScheme, localRegistration.Address, localRegistration.Port)
+		instance := service.FormatInstance(registrationScheme, registration.Address, registration.Port)
 		if r.Has(instance) {
 			l.Log(level.Key(), level.WarnValue(), logging.MessageKey(), "skipping duplicate registration", "instance", instance)
 			continue
 		}
 
 		if !co.disableGenerateID() {
-			ensureIDs(&localRegistration)
+			ensureIDs(&registration)
 		}
 
-		consulRegistrar, err = NewRegistrar(c, u, &localRegistration, log.With(l, "id", localRegistration.ID, "instance", instance))
+		consulRegistrar, err = NewRegistrar(c, u, &registration, log.With(l, "id", registration.ID, "instance", instance))
 		if err != nil {
 			return
 		}

--- a/service/consul/environment.go
+++ b/service/consul/environment.go
@@ -100,17 +100,19 @@ func newInstancers(l log.Logger, c gokitconsul.Client, co Options) (i service.In
 func newRegistrars(l log.Logger, registrationScheme string, c gokitconsul.Client, u ttlUpdater, co Options) (r service.Registrars, closer func() error, err error) {
 	var consulRegistrar sd.Registrar
 	for _, registration := range co.registrations() {
-		instance := service.FormatInstance(registrationScheme, registration.Address, registration.Port)
+		localRegistration := registration
+
+		instance := service.FormatInstance(registrationScheme, localRegistration.Address, localRegistration.Port)
 		if r.Has(instance) {
 			l.Log(level.Key(), level.WarnValue(), logging.MessageKey(), "skipping duplicate registration", "instance", instance)
 			continue
 		}
 
 		if !co.disableGenerateID() {
-			ensureIDs(&registration)
+			ensureIDs(&localRegistration)
 		}
 
-		consulRegistrar, err = NewRegistrar(c, u, &registration, log.With(l, "id", registration.ID, "instance", instance))
+		consulRegistrar, err = NewRegistrar(c, u, &localRegistration, log.With(l, "id", localRegistration.ID, "instance", instance))
 		if err != nil {
 			return
 		}

--- a/service/consul/environment_test.go
+++ b/service/consul/environment_test.go
@@ -132,8 +132,100 @@ func testNewEnvironmentFull(t *testing.T) {
 	ttlUpdater.AssertExpectations(t)
 }
 
+func testNewEnvironmentMultipleRegistrations(t *testing.T) {
+	defer resetClientFactory()
+
+	var (
+		assert  = assert.New(t)
+		require = require.New(t)
+
+		logger        = logging.NewTestLogger(nil, t)
+		clientFactory = prepareMockClientFactory()
+		client        = new(mockClient)
+		ttlUpdater    = new(mockTTLUpdater)
+
+		co = Options{
+			Client: &api.Config{
+				Address: "localhost:8500",
+				Scheme:  "https",
+			},
+			Registrations: []api.AgentServiceRegistration{
+				api.AgentServiceRegistration{
+					ID:      "service1",
+					Address: "grubly.com",
+					Port:    1111,
+				},
+				api.AgentServiceRegistration{
+					ID:      "service1",
+					Address: "grubly.local",
+					Port:    1111,
+				},
+			},
+			Watches: []Watch{
+				Watch{
+					Service:     "foobar",
+					Tags:        []string{"tag1"},
+					PassingOnly: true,
+				},
+				Watch{
+					Service:     "foobar",
+					Tags:        []string{"tag1"},
+					PassingOnly: true,
+				}, // duplicates should be ignored
+			},
+		}
+	)
+
+	clientFactory.On("NewClient", mock.MatchedBy(func(*api.Client) bool { return true })).Return(client, ttlUpdater).Once()
+
+	client.On("Service",
+		"foobar",
+		"tag1",
+		true,
+		mock.MatchedBy(func(qo *api.QueryOptions) bool { return qo != nil }),
+	).Return([]*api.ServiceEntry{}, new(api.QueryMeta), error(nil))
+
+	client.On("Register",
+		mock.MatchedBy(func(r *api.AgentServiceRegistration) bool {
+			return r.Address == "grubly.com" && r.Port == 1111
+		}),
+	).Return(error(nil)).Once()
+
+	client.On("Register",
+		mock.MatchedBy(func(r *api.AgentServiceRegistration) bool {
+			return r.Address == "grubly.local" && r.Port == 1111
+		}),
+	).Return(error(nil)).Once()
+
+	client.On("Deregister",
+		mock.MatchedBy(func(r *api.AgentServiceRegistration) bool {
+			return r.Address == "grubly.com" && r.Port == 1111
+		}),
+	).Return(error(nil)).Twice()
+
+	client.On("Deregister",
+		mock.MatchedBy(func(r *api.AgentServiceRegistration) bool {
+			return r.Address == "grubly.local" && r.Port == 1111
+		}),
+	).Return(error(nil)).Twice()
+
+	e, err := NewEnvironment(logger, "", co)
+	require.NoError(err)
+	require.NotNil(e)
+
+	e.Register()
+	e.Deregister()
+
+	assert.NoError(e.Close())
+
+	clientFactory.AssertExpectations(t)
+	client.AssertExpectations(t)
+	ttlUpdater.AssertExpectations(t)
+}
+
 func TestNewEnvironment(t *testing.T) {
 	t.Run("Empty", testNewEnvironmentEmpty)
 	t.Run("ClientError", testNewEnvironmentClientError)
 	t.Run("Full", testNewEnvironmentFull)
+	t.Run("MultipleRegistrations", testNewEnvironmentMultipleRegistrations)
 }


### PR DESCRIPTION
Hello,
In our environment we need talaria to register in consul with 2 endpoints, one for internal clients and another for the external clients. When we attempted this configuration, looking at tcpdumps we noticed that talaria registered 2 times using the same information (e.g. address, port).
This happens because, according to the spec, the reference to the `registration` may be re-used through all iterations of the loop:

> The iteration variables may be declared by the "range" clause using a form of short variable declaration (:=). In this case their types are set to the types of the respective iteration values and their scope is the block of the "for" statement; they are re-used in each iteration. If the iteration variables are declared outside the "for" statement, after execution their values will be those of the last iteration.

This PR creates a new reference to the `AgentServiceRegistration` while looping, effectively fixing the issue.