### PR TITLE
fix fanout: on sequential request returning a 503

### DIFF
--- a/xhttp/fanout/handler.go
+++ b/xhttp/fanout/handler.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/Comcast/webpa-common/logging"
 	"github.com/Comcast/webpa-common/tracing"
@@ -252,6 +253,9 @@ func (h *Handler) execute(logger log.Logger, spanner tracing.Spanner, results ch
 		}
 
 		if result.Err == context.Canceled || result.Err == context.DeadlineExceeded {
+			result.StatusCode = http.StatusGatewayTimeout
+		} else if strings.Contains(result.Err.Error(), "Client.Timeout exceeded while awaiting headers)") {
+			// handles an edge case where the request would be canceled before the deadline
 			result.StatusCode = http.StatusGatewayTimeout
 		} else {
 			result.StatusCode = http.StatusServiceUnavailable


### PR DESCRIPTION
On sequential request the request would occasionally return a 503 instead of a 504. This is because the client would timeout before the context would.