### PR TITLE
Fix SNS unsubscribe error

### DIFF
--- a/webhook/aws/sns_handler.go
+++ b/webhook/aws/sns_handler.go
@@ -348,9 +348,9 @@ func (ss *SNSServer) Unsubscribe(subArn string) {
 
 	if err != nil {
 		ss.errorLog.Log(logging.MessageKey(), "SNS Unsubscribe error", logging.ErrorKey(), err)
+	} else {
+		ss.debugLog.Log(logging.MessageKey(), "Successfully unsubscribed from the SNS topic", "response", resp)
 	}
-
-	ss.debugLog.Log(logging.MessageKey(), "Successfully unsubscribed from the SNS topic", "response", resp)
 }
 
 func (ss *SNSServer) UnsubscribeOldSubscriptions() {
@@ -402,7 +402,8 @@ func (ss *SNSServer) ListSubscriptionsByMatchingEndpoint() (*list.List, error) {
 		for _, sub := range resp.Subscriptions {
 			timestamp = 0
 			if !strings.EqualFold(*sub.Endpoint, ss.SelfUrl.String()) &&
-				strings.Contains(*sub.Endpoint, endpoint) {
+				strings.Contains(*sub.Endpoint, endpoint) &&
+				strings.Contains(*sub.subscriptionArn, ss.Config.Sns.TopicArn) {
 
 				fmt.Sscanf(*sub.Endpoint, endpoint+"/%d", &timestamp)
 				if timestamp == 0 || timestamp < currentTimestamp {

--- a/webhook/aws/sns_handler.go
+++ b/webhook/aws/sns_handler.go
@@ -403,7 +403,7 @@ func (ss *SNSServer) ListSubscriptionsByMatchingEndpoint() (*list.List, error) {
 			timestamp = 0
 			if !strings.EqualFold(*sub.Endpoint, ss.SelfUrl.String()) &&
 				strings.Contains(*sub.Endpoint, endpoint) &&
-				strings.Contains(*sub.subscriptionArn, ss.Config.Sns.TopicArn) {
+				strings.Contains(*sub.SubscriptionArn, ss.Config.Sns.TopicArn) {
 
 				fmt.Sscanf(*sub.Endpoint, endpoint+"/%d", &timestamp)
 				if timestamp == 0 || timestamp < currentTimestamp {


### PR DESCRIPTION
Associated Issue #362 

When unsubscribing from old SNS subscriptions, the
SubscriptionID (topicARN) was not being checked for
invalid values, such as "Deleted" or "PendingConfirmation"

Also fixes incorrect debug output when there is
an error returned from SNS internal "Unsubscribe"