### PR TITLE
renamed AllDataCenters to WatchAllByDatacenter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- renamed AllDataCenters to AcrossDatacenters
+- renamed AllDataCenters to CrossDatacenter [#502](https://github.com/xmidt-org/webpa-common/pull/502)
 
 ## [v1.10.4]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+- renamed AllDataCenters to WatchAllByDatacenter
 
 ## [v1.10.4]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- renamed AllDataCenters to WatchAllByDatacenter
+- renamed AllDataCenters to AcrossDatacenters
 
 ## [v1.10.4]
 ### Fixed

--- a/service/consul/environment.go
+++ b/service/consul/environment.go
@@ -130,7 +130,7 @@ func newInstancers(l log.Logger, c Client, co Options) (i service.Instancers, er
 	var datacenters []string
 
 	for _, w := range co.watches() {
-		if w.WatchAllByDatacenter {
+		if w.CrossDatacenter {
 			if len(datacenters) == 0 {
 				datacenters, err = getDatacenters(l, c, co)
 				if err != nil {

--- a/service/consul/environment.go
+++ b/service/consul/environment.go
@@ -68,14 +68,12 @@ func ensureIDs(r *api.AgentServiceRegistration) {
 }
 
 func newInstancerKey(w Watch) string {
-	datacenter := w.QueryOptions.Datacenter
-
 	return fmt.Sprintf(
 		"%s%s{passingOnly=%t}{datacenter=%s}",
 		w.Service,
 		w.Tags,
 		w.PassingOnly,
-		datacenter,
+		w.QueryOptions.Datacenter,
 	)
 }
 

--- a/service/consul/options.go
+++ b/service/consul/options.go
@@ -7,11 +7,11 @@ import (
 const DefaultDatacenterRetries = 10
 
 type Watch struct {
-	Service              string           `json:"service,omitempty"`
-	Tags                 []string         `json:"tags,omitempty"`
-	PassingOnly          bool             `json:"passingOnly"`
-	WatchAllByDatacenter bool             `json:"watchAllByDatacenter"`
-	QueryOptions         api.QueryOptions `json:"queryOptions"`
+	Service         string           `json:"service,omitempty"`
+	Tags            []string         `json:"tags,omitempty"`
+	PassingOnly     bool             `json:"passingOnly"`
+	CrossDatacenter bool             `json:"crossDatacenter"`
+	QueryOptions    api.QueryOptions `json:"queryOptions"`
 }
 
 type Options struct {

--- a/service/consul/options.go
+++ b/service/consul/options.go
@@ -7,11 +7,11 @@ import (
 const DefaultDatacenterRetries = 10
 
 type Watch struct {
-	Service        string           `json:"service,omitempty"`
-	Tags           []string         `json:"tags,omitempty"`
-	PassingOnly    bool             `json:"passingOnly"`
-	AllDatacenters bool             `json:"allDatacenters"`
-	QueryOptions   api.QueryOptions `json:"queryOptions"`
+	Service              string           `json:"service,omitempty"`
+	Tags                 []string         `json:"tags,omitempty"`
+	PassingOnly          bool             `json:"passingOnly"`
+	WatchAllByDatacenter bool             `json:"watchAllByDatacenter"`
+	QueryOptions         api.QueryOptions `json:"queryOptions"`
 }
 
 type Options struct {


### PR DESCRIPTION
This separates out any confusion on how the list of instances appear in the MonitorEvent function. We may want to add AllDatacenters back for when we want the list of all nodes across all datacenters. 