### PR TITLE
Add default content for all WRP messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed serviceEndpoints unit tests failing. [#510](https://github.com/xmidt-org/webpa-common/pull/510)
 
 ### Changed
-- Add configurable check for the source of inbound (device => cloud service) WRP messages. [#507] (https://github.com/xmidt-org/webpa-common/pull/507)
-- Populate empty inbound WRP.content_type field with application/octet-stream [#508](https://github.com/xmidt-org/webpa-common/pull/508)
+- Add configurable check for the source of inbound (device => cloud service) WRP messages. [#507](https://github.com/xmidt-org/webpa-common/pull/507)
+- Populate empty inbound WRP.content_type field with `application/octet-stream`. [#508](https://github.com/xmidt-org/webpa-common/pull/508)
 
 ## [v1.10.6]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Add configurable check for the source of inbound (device => cloud service) WRP messages. [#507] (https://github.com/xmidt-org/webpa-common/pull/507)
 
+## Changed 
+- Populate empty inbound WRP.content_type field with application/octet-stream [#508](https://github.com/xmidt-org/webpa-common/pull/508)
+
 ## [v1.10.6]
 ### Fixed
 - Fixed ServiceEndpoints not faning out when a datacenter is empty [#504](https://github.com/xmidt-org/webpa-common/pull/504)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Add configurable check for the source of inbound (device => cloud service) WRP messages. [#507] (https://github.com/xmidt-org/webpa-common/pull/507)
-
-## Changed 
 - Populate empty inbound WRP.content_type field with application/octet-stream [#508](https://github.com/xmidt-org/webpa-common/pull/508)
 
 ## [v1.10.6]

--- a/device/manager.go
+++ b/device/manager.go
@@ -21,6 +21,9 @@ import (
 
 const MaxDevicesHeader = "X-Xmidt-Max-Devices"
 
+// DefaultWRPContentType is the content type used on inbound WRP messages which don't provide one.
+const DefaultWRPContentType = "application/octet-stream"
+
 // Connector is a strategy interface for managing device connections to a server.
 // Implementations are responsible for upgrading websocket connections and providing
 // for explicit disconnection.
@@ -356,6 +359,10 @@ func (m *manager) readPump(d *device, r ReadCloser, closeOnce *sync.Once) {
 		if !m.wrpSourceIsValid(message, d.ID()) {
 			d.errorLog.Log(logging.MessageKey(), "skipping WRP message with invalid source")
 			continue
+		}
+
+		if len(strings.TrimSpace(message.ContentType)) == 0 {
+			message.ContentType = DefaultWRPContentType
 		}
 
 		addDeviceMetadataContext(message, d.Metadata())


### PR DESCRIPTION
This is related to https://github.com/xmidt-org/talaria/issues/148

Although the issue says Simple Events only, should we not also apply these to all kinds for consistency? 