### PR TITLE
Add eventKey to service discovery metric 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added eventKey to service discovery metric [#509](https://github.com/xmidt-org/webpa-common/pull/509)
 
 ## [v1.10.6]
 ### Fixed

--- a/service/metrics.go
+++ b/service/metrics.go
@@ -11,7 +11,8 @@ const (
 	LastErrorTimestamp  = "sd_last_error_timestamp"
 	LastUpdateTimestamp = "sd_last_update_timestamp"
 
-	ServiceLabel = "service"
+	ServiceLabel  = "service"
+	EventKeyLabel = "eventKey"
 )
 
 // Metrics is the service discovery module function for metrics
@@ -21,31 +22,31 @@ func Metrics() []xmetrics.Metric {
 			Name:       ErrorCount,
 			Type:       "counter",
 			Help:       "The total count of errors from the service discovery backend for a particular service",
-			LabelNames: []string{ServiceLabel},
+			LabelNames: []string{ServiceLabel, EventKeyLabel},
 		},
 		{
 			Name:       UpdateCount,
 			Type:       "counter",
 			Help:       "The total count of updates from the service discovery backend for a particular service",
-			LabelNames: []string{ServiceLabel},
+			LabelNames: []string{ServiceLabel, EventKeyLabel},
 		},
 		{
 			Name:       InstanceCount,
 			Type:       "gauge",
 			Help:       "The current number of service instances of a given type",
-			LabelNames: []string{ServiceLabel},
+			LabelNames: []string{ServiceLabel, EventKeyLabel},
 		},
 		{
 			Name:       LastErrorTimestamp,
 			Type:       "gauge",
 			Help:       "The last time the service discovery backend sent an error for a given service",
-			LabelNames: []string{ServiceLabel},
+			LabelNames: []string{ServiceLabel, EventKeyLabel},
 		},
 		{
 			Name:       LastUpdateTimestamp,
 			Type:       "gauge",
 			Help:       "The last time the service discovery backend sent updated instances for a given service",
-			LabelNames: []string{ServiceLabel},
+			LabelNames: []string{ServiceLabel, EventKeyLabel},
 		},
 	}
 }

--- a/service/monitor/listener.go
+++ b/service/monitor/listener.go
@@ -76,14 +76,14 @@ func NewMetricsListener(p provider.Provider) Listener {
 		timestamp := float64(time.Now().Unix())
 
 		if e.Err != nil {
-			errorCount.With(service.ServiceLabel, e.Service).Add(1.0)
-			lastError.With(service.ServiceLabel, e.Service).Set(timestamp)
+			errorCount.With(service.ServiceLabel, e.Service, service.EventKeyLabel, e.Key).Add(1.0)
+			lastError.With(service.ServiceLabel, e.Service, service.EventKeyLabel, e.Key).Set(timestamp)
 		} else {
-			updateCount.With(service.ServiceLabel, e.Service).Add(1.0)
-			lastUpdate.With(service.ServiceLabel, e.Service).Set(timestamp)
+			updateCount.With(service.ServiceLabel, e.Service, service.EventKeyLabel, e.Key).Add(1.0)
+			lastUpdate.With(service.ServiceLabel, e.Service, service.EventKeyLabel, e.Key).Set(timestamp)
 		}
 
-		instanceCount.With(service.ServiceLabel, e.Service).Set(float64(len(e.Instances)))
+		instanceCount.With(service.ServiceLabel, e.Service, service.EventKeyLabel, e.Key).Set(float64(len(e.Instances)))
 	})
 }
 

--- a/service/monitor/listener_test.go
+++ b/service/monitor/listener_test.go
@@ -76,11 +76,11 @@ func testNewMetricsListenerUpdate(t *testing.T) {
 		now = float64(time.Now().Unix())
 
 		p = xmetricstest.NewProvider(nil, service.Metrics).
-			Expect(service.UpdateCount, service.ServiceLabel, "talaria")(xmetricstest.Value(1.0)).
-			Expect(service.LastUpdateTimestamp, service.ServiceLabel, "talaria")(xmetricstest.Minimum(now)).
-			Expect(service.ErrorCount, service.ServiceLabel, "talaria")(xmetricstest.Value(0.0)).
-			Expect(service.LastErrorTimestamp, service.ServiceLabel, "talaria")(xmetricstest.Value(0.0)).
-			Expect(service.InstanceCount, service.ServiceLabel, "talaria")(xmetricstest.Value(2.0))
+			Expect(service.UpdateCount, service.ServiceLabel, "talaria", service.EventKeyLabel, "test")(xmetricstest.Value(1.0)).
+			Expect(service.LastUpdateTimestamp, service.ServiceLabel, "talaria", service.EventKeyLabel, "test")(xmetricstest.Minimum(now)).
+			Expect(service.ErrorCount, service.ServiceLabel, "talaria", service.EventKeyLabel, "test")(xmetricstest.Value(0.0)).
+			Expect(service.LastErrorTimestamp, service.ServiceLabel, "talaria", service.EventKeyLabel, "test")(xmetricstest.Value(0.0)).
+			Expect(service.InstanceCount, service.ServiceLabel, "talaria", service.EventKeyLabel, "test")(xmetricstest.Value(2.0))
 		l = NewMetricsListener(p)
 	)
 
@@ -93,11 +93,11 @@ func testNewMetricsListenerError(t *testing.T) {
 		now = float64(time.Now().Unix())
 
 		p = xmetricstest.NewProvider(nil, service.Metrics).
-			Expect(service.UpdateCount, service.ServiceLabel, "scytale")(xmetricstest.Value(0.0)).
-			Expect(service.LastUpdateTimestamp, service.ServiceLabel, "scytale")(xmetricstest.Value(0.0)).
-			Expect(service.ErrorCount, service.ServiceLabel, "scytale")(xmetricstest.Value(1.0)).
-			Expect(service.LastErrorTimestamp, service.ServiceLabel, "scytale")(xmetricstest.Minimum(now)).
-			Expect(service.InstanceCount, service.ServiceLabel, "scytale")(xmetricstest.Value(0.0))
+			Expect(service.UpdateCount, service.ServiceLabel, "scytale", service.EventKeyLabel, "test")(xmetricstest.Value(0.0)).
+			Expect(service.LastUpdateTimestamp, service.ServiceLabel, "scytale", service.EventKeyLabel, "test")(xmetricstest.Value(0.0)).
+			Expect(service.ErrorCount, service.ServiceLabel, "scytale", service.EventKeyLabel, "test")(xmetricstest.Value(1.0)).
+			Expect(service.LastErrorTimestamp, service.ServiceLabel, "scytale", service.EventKeyLabel, "test")(xmetricstest.Minimum(now)).
+			Expect(service.InstanceCount, service.ServiceLabel, "scytale", service.EventKeyLabel, "test")(xmetricstest.Value(0.0))
 		l = NewMetricsListener(p)
 	)
 


### PR DESCRIPTION
The metric would be wrong if the flag `crossDatacenter` was enabled. 