### PR TITLE
Update logic for Inbound WRP Source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added `trust` label to hardware_model gauge. [#512](https://github.com/xmidt-org/webpa-common/pull/512)
 
 ### Fixed
-- Fixed serviceEndpoints unit tests failing. [#510](https://github.com/xmidt-org/webpa-common/pull/510)
+- Fix serviceEndpoints unit tests failing. [#510](https://github.com/xmidt-org/webpa-common/pull/510)
+- Fix device Metadata Trust() method float64 casting to int. [#511](https://github.com/xmidt-org/webpa-common/pull/511)
 
 ### Changed
 - Add configurable check for the source of inbound (device => cloud service) WRP messages. [#507](https://github.com/xmidt-org/webpa-common/pull/507)
 - Populate empty inbound WRP.content_type field with `application/octet-stream`. [#508](https://github.com/xmidt-org/webpa-common/pull/508)
+- Update inbound WRP source check logic. [#511](https://github.com/xmidt-org/webpa-common/pull/511)
 
 
 ## [v1.10.6]

--- a/device/options.go
+++ b/device/options.go
@@ -73,14 +73,11 @@ type Options struct {
 	Now func() time.Time
 
 	// WRPSourceCheck defines behavior around checking the Source field in WRP messages originating
-	// from this device. The current check cases are:
-	// 1) Source is empty: leaving this field empty suggests very little chance of underlying bad intent
-	//    so the field is populated with the device's canonical ID (i.e. mac:112233445566).
-	// 2) Canonical ID can't be parsed from Source: a bad actor could be behind this behavior and thus the
-	//    message is dropped on the floor when the check type is "enforce".
-	// 3) Canonical ID doesn't match that of the established websocket connection: this is the most obvious case in
-	//    which a bad actor could have a device pretend sending messages oh behalf of another.
-	// Note: when the check type is "monitor", no messages are dropped but they are logged as part of the "wrp_source_check"
+	// from devices. All the following are cases of an invalid WRP wrt the source:
+	// 1) Source is empty.
+	// 2) Canonical ID can't be parsed from Source.
+	// 3) Canonical ID doesn't match that of the established websocket connection.
+	// Note: when the check type is "monitor", no messages are dropped but they are logged as an error and update the "wrp_source_check"
 	// counter.
 	WRPSourceCheck wrpSourceCheckConfig
 }


### PR DESCRIPTION
During team discussions, we found _**log entries**_ will be helpful on top of the metrics to check validation errors. 
Another update is making an **_empty source part of the cases for an invalid WRP message_** since that would represent at best a bug in the system. 