### PR TITLE
Fix bug in which tls could not be enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Fixed
+- Bug in which only mTLS was allowed as valid config for an HTTP server. [#544](https://github.com/xmidt-org/webpa-common/pull/544)
 
 ## [v1.11.2]
 ### Changed


### PR DESCRIPTION
Found this while attempting to run the webhook-transition code and realizing it always fails when only TLS is requested.

This is related to https://github.com/xmidt-org/webpa-common/pull/529https://github.com/xmidt-org/webpa-common/pull/529. I think there might've been some confusion about the `generateCerts` function name. I renamed it to `loadCerts` as all it does is validate cert/key pairs and loads them (not generate them). 

