### PR TITLE
revert to two commands as test results are cached

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,8 @@ script:
   # In PR, changes were made to fix intermittently failing tests
   # Filter out packages of low impact (not used anywhere else in xmidt) that have this issue.
 
-  - go test -v -race -json -coverprofile=coverage.txt `go list ./... | grep -v ".*bookkeeping"` > report.json
+  - go test -v -race -coverprofile=coverage.txt `go list ./... | grep -v ".*bookkeeping"`
+  - go test -v -race -json `go list ./... | grep -v ".*bookkeeping"` > report.json
 
 after_success:
   - sonar-scanner -Dproject.settings=./.sonar-project.properties


### PR DESCRIPTION
Other reasons to revert:
- Test log streaming is nice in case of failures that need debugging
- Even if we could use commands like `tee`, the json output is not very human readable