### PR TITLE
CounterVec version of bascule metric providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Update uber/fx measures setup-code for basculechecks and basculemetrics. [#558](https://github.com/xmidt-org/webpa-common/pull/558)
 - Update code to use the latest Argus changes. [#557](https://github.com/xmidt-org/webpa-common/pull/557)
+
+### Added
 - Add ability to drain devices by specific parameters. [#554](https://github.com/xmidt-org/webpa-common/pull/554)
 - Add filtering capability to gate device connections. [#547](https://github.com/xmidt-org/webpa-common/pull/547)
 

--- a/basculechecks/metrics.go
+++ b/basculechecks/metrics.go
@@ -63,7 +63,7 @@ const (
 	EmptyParsedURL           = "empty_parsed_URL"
 )
 
-// Metrics returns the Metrics relevant to this package targetting our older non uber/fx applications.
+// Metrics returns the Metrics relevant to this package targeting our older non uber/fx applications.
 // To initialize the metrics, use NewAuthCapabilityCheckMeasures().
 func Metrics() []xmetrics.Metric {
 	return []xmetrics.Metric{

--- a/basculechecks/metrics.go
+++ b/basculechecks/metrics.go
@@ -39,6 +39,7 @@ const (
 	ClientIDLabel  = "clientid"
 	EndpointLabel  = "endpoint"
 	PartnerIDLabel = "partnerid"
+	ServerLabel = "server"
 )
 
 // outcomes
@@ -63,7 +64,7 @@ func Metrics() []xmetrics.Metric {
 			Name:       AuthCapabilityCheckOutcome,
 			Type:       xmetrics.CounterType,
 			Help:       "Counter for the capability checker, providing outcome information by client, partner, and endpoint",
-			LabelNames: []string{OutcomeLabel, ReasonLabel, ClientIDLabel, PartnerIDLabel, EndpointLabel},
+			LabelNames: []string{ServerLabel, OutcomeLabel, ReasonLabel, ClientIDLabel, PartnerIDLabel, EndpointLabel},
 		},
 	}
 }
@@ -74,15 +75,24 @@ func ProvideMetrics() fx.Option {
 			Name:        AuthCapabilityCheckOutcome,
 			Help:        "Counter for the capability checker, providing outcome information by client, partner, and endpoint",
 			ConstLabels: nil,
-		}, OutcomeLabel, ReasonLabel, ClientIDLabel, PartnerIDLabel, EndpointLabel),
+		}, ServerLabel, OutcomeLabel, ReasonLabel, ClientIDLabel, PartnerIDLabel, EndpointLabel),
+	)
+}
+
+
+func ProvideMetricsVec() fx.Option {
+	return fx.Provide(
+		themisXmetrics.ProvideCounterVec(prometheus.CounterOpts{
+			Name:        AuthCapabilityCheckOutcome,
+			Help:        "Counter for the capability checker, providing outcome information by client, partner, and endpoint",
+			ConstLabels: nil,
+		}, ServerLabel, OutcomeLabel, ReasonLabel, ClientIDLabel, PartnerIDLabel, EndpointLabel),
 	)
 }
 
 // AuthCapabilityCheckMeasures describes the defined metrics that will be used by clients
 type AuthCapabilityCheckMeasures struct {
-	fx.In
-
-	CapabilityCheckOutcome metrics.Counter `name:"auth_capability_check"`
+	CapabilityCheckOutcome metrics.Counter
 }
 
 // NewAuthCapabilityCheckMeasures realizes desired metrics

--- a/basculechecks/metrics.go
+++ b/basculechecks/metrics.go
@@ -63,6 +63,13 @@ const (
 	EmptyParsedURL           = "empty_parsed_URL"
 )
 
+// help messages
+const (
+	capabilityCheckHelpMsg =       "Counter for the capability checker, providing outcome information by client, partner, and endpoint",
+
+
+)
+
 // Metrics returns the Metrics relevant to this package targeting our older non uber/fx applications.
 // To initialize the metrics, use NewAuthCapabilityCheckMeasures().
 func Metrics() []xmetrics.Metric {
@@ -70,7 +77,7 @@ func Metrics() []xmetrics.Metric {
 		{
 			Name:       AuthCapabilityCheckOutcome,
 			Type:       xmetrics.CounterType,
-			Help:       "Counter for the capability checker, providing outcome information by client, partner, and endpoint",
+			Help:       capabilityCheckHelpMsg,
 			LabelNames: []string{OutcomeLabel, ReasonLabel, ClientIDLabel, PartnerIDLabel, EndpointLabel},
 		},
 	}
@@ -82,7 +89,7 @@ func ProvideMetrics() fx.Option {
 	return fx.Provide(
 		themisXmetrics.ProvideCounter(prometheus.CounterOpts{
 			Name:        AuthCapabilityCheckOutcome,
-			Help:        "Counter for the capability checker, providing outcome information by client, partner, and endpoint",
+			Help:        capabilityCheckHelpMsg,
 			ConstLabels: nil,
 		}, OutcomeLabel, ReasonLabel, ClientIDLabel, PartnerIDLabel, EndpointLabel),
 	)
@@ -94,7 +101,7 @@ func ProvideMetricsVec() fx.Option {
 	return fx.Provide(
 		themisXmetrics.ProvideCounterVec(prometheus.CounterOpts{
 			Name:        AuthCapabilityCheckOutcome,
-			Help:        "Counter for the capability checker, providing outcome information by client, partner, and endpoint",
+			Help:        capabilityCheckHelpMsg,
 			ConstLabels: nil,
 		}, ServerLabel, OutcomeLabel, ReasonLabel, ClientIDLabel, PartnerIDLabel, EndpointLabel),
 	)

--- a/basculechecks/metrics.go
+++ b/basculechecks/metrics.go
@@ -18,9 +18,15 @@
 package basculechecks
 
 import (
+	"fmt"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
 	"github.com/go-kit/kit/metrics"
+	gokitprometheus "github.com/go-kit/kit/metrics/prometheus"
 	"github.com/go-kit/kit/metrics/provider"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/xmidt-org/themis/xlog"
 	themisXmetrics "github.com/xmidt-org/themis/xmetrics"
 	"github.com/xmidt-org/webpa-common/xmetrics"
 
@@ -39,7 +45,7 @@ const (
 	ClientIDLabel  = "clientid"
 	EndpointLabel  = "endpoint"
 	PartnerIDLabel = "partnerid"
-	ServerLabel = "server"
+	ServerLabel    = "server"
 )
 
 // outcomes
@@ -57,29 +63,33 @@ const (
 	EmptyParsedURL           = "empty_parsed_URL"
 )
 
-// Metrics returns the Metrics relevant to this package
+// Metrics returns the Metrics relevant to this package targetting our older non uber/fx applications.
+// To initialize the metrics, use NewAuthCapabilityCheckMeasures().
 func Metrics() []xmetrics.Metric {
 	return []xmetrics.Metric{
 		{
 			Name:       AuthCapabilityCheckOutcome,
 			Type:       xmetrics.CounterType,
 			Help:       "Counter for the capability checker, providing outcome information by client, partner, and endpoint",
-			LabelNames: []string{ServerLabel, OutcomeLabel, ReasonLabel, ClientIDLabel, PartnerIDLabel, EndpointLabel},
+			LabelNames: []string{OutcomeLabel, ReasonLabel, ClientIDLabel, PartnerIDLabel, EndpointLabel},
 		},
 	}
 }
 
+// ProvideMetrics provides the metrics relevant to this package as uber/fx options.
+// This is now deprecated in favor of ProvideMetricsVec.
 func ProvideMetrics() fx.Option {
 	return fx.Provide(
 		themisXmetrics.ProvideCounter(prometheus.CounterOpts{
 			Name:        AuthCapabilityCheckOutcome,
 			Help:        "Counter for the capability checker, providing outcome information by client, partner, and endpoint",
 			ConstLabels: nil,
-		}, ServerLabel, OutcomeLabel, ReasonLabel, ClientIDLabel, PartnerIDLabel, EndpointLabel),
+		}, OutcomeLabel, ReasonLabel, ClientIDLabel, PartnerIDLabel, EndpointLabel),
 	)
 }
 
-
+// ProvideMetricsVec provides the metrics relevant to this package as uber/fx options.
+// The provided metrics are prometheus vectors which gives access to more advanced operations such as CurryWith(labels).
 func ProvideMetricsVec() fx.Option {
 	return fx.Provide(
 		themisXmetrics.ProvideCounterVec(prometheus.CounterOpts{
@@ -95,9 +105,43 @@ type AuthCapabilityCheckMeasures struct {
 	CapabilityCheckOutcome metrics.Counter
 }
 
-// NewAuthCapabilityCheckMeasures realizes desired metrics
+// NewAuthCapabilityCheckMeasures realizes desired metrics. It's intended to be used alongside Metrics() for
+// our older non uber/fx applications.
 func NewAuthCapabilityCheckMeasures(p provider.Provider) *AuthCapabilityCheckMeasures {
 	return &AuthCapabilityCheckMeasures{
 		CapabilityCheckOutcome: p.NewCounter(AuthCapabilityCheckOutcome),
+	}
+}
+
+// BaseMeasuresIn is an uber/fx parameter with base metrics ready to be curried into child metrics based on
+// custom labels.
+type BaseMeasuresIn struct {
+	fx.In
+	Logger                 log.Logger
+	CapabilityCheckOutcome *prometheus.CounterVec `name:"auth_capability_check"`
+}
+
+// MeasuresFactory facilitates the creation of child metrics based on server labels.
+type MeasuresFactory struct {
+	ServerName string
+}
+
+// NewMeasures builds the metric listener from the provided raw metrics.
+func (m MeasuresFactory) NewMeasures(in BaseMeasuresIn) (*AuthCapabilityCheckMeasures, error) {
+	capabilityCheckOutcomeCounterVec, err := in.CapabilityCheckOutcome.CurryWith(prometheus.Labels{ServerLabel: m.ServerName})
+	if err != nil {
+		return nil, err
+	}
+	in.Logger.Log(level.Key(), level.DebugValue(), xlog.MessageKey(), "building auth capability measures", ServerLabel, m.ServerName)
+	return &AuthCapabilityCheckMeasures{
+		CapabilityCheckOutcome: gokitprometheus.NewCounter(capabilityCheckOutcomeCounterVec),
+	}, nil
+}
+
+// Annotated provides the measures as an annotated component with the name "[SERVER]_capability_measures"
+func (m MeasuresFactory) Annotated() fx.Annotated {
+	return fx.Annotated{
+		Name:   fmt.Sprintf("%s_capability_measures", m.ServerName),
+		Target: m.NewMeasures,
 	}
 }

--- a/basculechecks/metrics.go
+++ b/basculechecks/metrics.go
@@ -65,9 +65,7 @@ const (
 
 // help messages
 const (
-	capabilityCheckHelpMsg =       "Counter for the capability checker, providing outcome information by client, partner, and endpoint",
-
-
+	capabilityCheckHelpMsg = "Counter for the capability checker, providing outcome information by client, partner, and endpoint"
 )
 
 // Metrics returns the Metrics relevant to this package targeting our older non uber/fx applications.

--- a/basculemetrics/metrics.go
+++ b/basculemetrics/metrics.go
@@ -27,7 +27,7 @@ const (
 	ServerLabel  = "server"
 )
 
-// Metrics returns the Metrics relevant to this package targetting our older non uber/fx applications.
+// Metrics returns the Metrics relevant to this package targeting our older non uber/fx applications.
 // To initialize the metrics, use NewAuthValidationMeasures().
 func Metrics() []xmetrics.Metric {
 	return []xmetrics.Metric{

--- a/basculemetrics/metrics.go
+++ b/basculemetrics/metrics.go
@@ -19,28 +19,31 @@ const (
 // labels
 const (
 	OutcomeLabel = "outcome"
+	ServerLabel = "server"
 )
 
 // Metrics returns the Metrics relevant to this package
 func Metrics() []xmetrics.Metric {
 	return []xmetrics.Metric{
-		xmetrics.Metric{
+		{
 			Name:       AuthValidationOutcome,
 			Type:       xmetrics.CounterType,
 			Help:       "Counter for success and failure reason results through bascule",
-			LabelNames: []string{OutcomeLabel},
+			LabelNames: []string{ServerLabel, OutcomeLabel},
 		},
-		xmetrics.Metric{
+		{
 			Name:    NBFHistogram,
 			Type:    xmetrics.HistogramType,
 			Help:    "Difference (in seconds) between time of JWT validation and nbf (including leeway)",
 			Buckets: []float64{-61, -11, -2, -1, 0, 9, 60}, // defines the upper inclusive (<=) bounds
+			LabelNames: []string{ServerLabel},
 		},
-		xmetrics.Metric{
+		{
 			Name:    EXPHistogram,
 			Type:    xmetrics.HistogramType,
 			Help:    "Difference (in seconds) between time of JWT validation and exp (including leeway)",
 			Buckets: []float64{-61, -11, -2, -1, 0, 9, 60},
+			LabelNames: []string{ServerLabel},
 		},
 	}
 }
@@ -62,6 +65,26 @@ func ProvideMetrics() fx.Option {
 			Help:    "Difference (in seconds) between time of JWT validation and exp (including leeway)",
 			Buckets: []float64{-61, -11, -2, -1, 0, 9, 60},
 		}),
+	)
+}
+
+func ProvideMetricsVec() fx.Option {
+	return fx.Provide(
+		themisXmetrics.ProvideCounterVec(prometheus.CounterOpts{
+			Name:        AuthValidationOutcome,
+			Help:        "Counter for the capability checker, providing outcome information by client, partner, and endpoint",
+			ConstLabels: nil,
+		}, ServerLabel, OutcomeLabel),
+		themisXmetrics.ProvideHistogramVec(prometheus.HistogramOpts{
+			Name:    NBFHistogram,
+			Help:    "Difference (in seconds) between time of JWT validation and nbf (including leeway)",
+			Buckets: []float64{-61, -11, -2, -1, 0, 9, 60}, // defines the upper inclusive (<=) bounds
+		}, ServerLabel),
+		themisXmetrics.ProvideHistogramVec(prometheus.HistogramOpts{
+			Name:    EXPHistogram,
+			Help:    "Difference (in seconds) between time of JWT validation and exp (including leeway)",
+			Buckets: []float64{-61, -11, -2, -1, 0, 9, 60},
+		}, ServerLabel),
 	)
 }
 

--- a/basculemetrics/metrics.go
+++ b/basculemetrics/metrics.go
@@ -27,6 +27,13 @@ const (
 	ServerLabel  = "server"
 )
 
+// help messages
+const (
+	authValidationOutcomeHelpMsg = "Counter for success and failure reason results through bascule"
+	nbfHelpMsg                   = "Difference (in seconds) between time of JWT validation and nbf (including leeway)"
+	expHelpMsg                   = "Difference (in seconds) between time of JWT validation and exp (including leeway)"
+)
+
 // Metrics returns the Metrics relevant to this package targeting our older non uber/fx applications.
 // To initialize the metrics, use NewAuthValidationMeasures().
 func Metrics() []xmetrics.Metric {
@@ -34,20 +41,20 @@ func Metrics() []xmetrics.Metric {
 		{
 			Name:       AuthValidationOutcome,
 			Type:       xmetrics.CounterType,
-			Help:       "Counter for success and failure reason results through bascule",
+			Help:       authValidationOutcomeHelpMsg,
 			LabelNames: []string{ServerLabel, OutcomeLabel},
 		},
 		{
 			Name:       NBFHistogram,
 			Type:       xmetrics.HistogramType,
-			Help:       "Difference (in seconds) between time of JWT validation and nbf (including leeway)",
+			Help:       nbfHelpMsg,
 			Buckets:    []float64{-61, -11, -2, -1, 0, 9, 60}, // defines the upper inclusive (<=) bounds
 			LabelNames: []string{ServerLabel},
 		},
 		{
 			Name:       EXPHistogram,
 			Type:       xmetrics.HistogramType,
-			Help:       "Difference (in seconds) between time of JWT validation and exp (including leeway)",
+			Help:       expHelpMsg,
 			Buckets:    []float64{-61, -11, -2, -1, 0, 9, 60},
 			LabelNames: []string{ServerLabel},
 		},
@@ -60,17 +67,18 @@ func ProvideMetrics() fx.Option {
 	return fx.Provide(
 		themisXmetrics.ProvideCounter(prometheus.CounterOpts{
 			Name:        AuthValidationOutcome,
-			Help:        "Counter for the capability checker, providing outcome information by client, partner, and endpoint",
+			Help:        authValidationOutcomeHelpMsg,
 			ConstLabels: nil,
 		}, OutcomeLabel),
 		themisXmetrics.ProvideHistogram(prometheus.HistogramOpts{
-			Name:    NBFHistogram,
-			Help:    "Difference (in seconds) between time of JWT validation and nbf (including leeway)",
+			Name: NBFHistogram,
+
+			Help:    nbfHelpMsg,
 			Buckets: []float64{-61, -11, -2, -1, 0, 9, 60}, // defines the upper inclusive (<=) bounds
 		}),
 		themisXmetrics.ProvideHistogram(prometheus.HistogramOpts{
 			Name:    EXPHistogram,
-			Help:    "Difference (in seconds) between time of JWT validation and exp (including leeway)",
+			Help:    expHelpMsg,
 			Buckets: []float64{-61, -11, -2, -1, 0, 9, 60},
 		}),
 	)
@@ -82,17 +90,17 @@ func ProvideMetricsVec() fx.Option {
 	return fx.Provide(
 		themisXmetrics.ProvideCounterVec(prometheus.CounterOpts{
 			Name:        AuthValidationOutcome,
-			Help:        "Counter for the capability checker, providing outcome information by client, partner, and endpoint",
+			Help:        authValidationOutcomeHelpMsg,
 			ConstLabels: nil,
 		}, ServerLabel, OutcomeLabel),
 		themisXmetrics.ProvideHistogramVec(prometheus.HistogramOpts{
 			Name:    NBFHistogram,
-			Help:    "Difference (in seconds) between time of JWT validation and nbf (including leeway)",
+			Help:    nbfHelpMsg,
 			Buckets: []float64{-61, -11, -2, -1, 0, 9, 60}, // defines the upper inclusive (<=) bounds
 		}, ServerLabel),
 		themisXmetrics.ProvideHistogramVec(prometheus.HistogramOpts{
 			Name:    EXPHistogram,
-			Help:    "Difference (in seconds) between time of JWT validation and exp (including leeway)",
+			Help:    expHelpMsg,
 			Buckets: []float64{-61, -11, -2, -1, 0, 9, 60},
 		}, ServerLabel),
 	)


### PR DESCRIPTION
In order to partition metrics based on the different servers the bascule profiles (introduced in https://github.com/xmidt-org/argus/issues/97) target, we need the CounterVecs so we can leverage https://pkg.go.dev/github.com/prometheus/client_golang/prometheus#CounterVec.CurryWith