### PR TITLE
Feature/strong ciphers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Enforce cipher suites for TLS versions less than 1.3 that are not vulnerable to SWEET32
 
 ## [v2.0.3]
 - Bumped argus to v0.6.0 and fixed related datacenter watch code. [#589](https://github.com/xmidt-org/webpa-common/pull/589)

--- a/server/webpa.go
+++ b/server/webpa.go
@@ -45,8 +45,8 @@ var (
 	// ErrorNoPrimaryAddress is the error returned when no primary address is specified in a WebPA instance
 	ErrorNoPrimaryAddress = errors.New("No primary address configured")
 
-	// safeCipherSuites are the tls.CipherSuite values that are safe for TLS versions less than 1.3
-	safeCipherSuites = []uint16{
+	// strongCipherSuites are the tls.CipherSuite values that are safe for TLS versions less than 1.3
+	strongCipherSuites = []uint16{
 		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
 		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
 	}
@@ -287,7 +287,7 @@ func (b *Basic) New(logger log.Logger, handler http.Handler) *http.Server {
 			MaxVersion:   b.maxVersion(),
 
 			// ensure strong ciphers when the TLS version is 1.2 or less
-			CipherSuites: safeCipherSuites,
+			CipherSuites: strongCipherSuites,
 		}
 
 		if len(b.ClientCACertFile) > 0 {

--- a/server/webpa.go
+++ b/server/webpa.go
@@ -44,6 +44,12 @@ const (
 var (
 	// ErrorNoPrimaryAddress is the error returned when no primary address is specified in a WebPA instance
 	ErrorNoPrimaryAddress = errors.New("No primary address configured")
+
+	// safeCipherSuites are the tls.CipherSuite values that are safe for TLS versions less than 1.3
+	safeCipherSuites = []uint16{
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+	}
 )
 
 // executor is an internal type used to start an HTTP server.  *http.Server implements
@@ -279,6 +285,9 @@ func (b *Basic) New(logger log.Logger, handler http.Handler) *http.Server {
 			Certificates: certs,
 			MinVersion:   b.minVersion(),
 			MaxVersion:   b.maxVersion(),
+
+			// ensure strong ciphers when the TLS version is 1.2 or less
+			CipherSuites: safeCipherSuites,
 		}
 
 		if len(b.ClientCACertFile) > 0 {


### PR DESCRIPTION
We aren't currently running SSL for the metrics and health endpoints.  But this just enforces the strong cipher suites that don't have the SWEET32 vulnerability.