### PR TITLE
bug: Remove a bad `TestHealthRequestTracker` unit test case

### DIFF
--- a/health/health_test.go
+++ b/health/health_test.go
@@ -140,7 +140,6 @@ func TestHealthRequestTracker(t *testing.T) {
 			expectedStats      Stats
 		}{
 			// success codes
-			{0, Stats{TotalRequestsReceived: 1, TotalRequestsSuccessfullyServiced: 1, TotalRequestsDenied: 0}},
 			{100, Stats{TotalRequestsReceived: 1, TotalRequestsSuccessfullyServiced: 1, TotalRequestsDenied: 0}},
 			{200, Stats{TotalRequestsReceived: 1, TotalRequestsSuccessfullyServiced: 1, TotalRequestsDenied: 0}},
 			{201, Stats{TotalRequestsReceived: 1, TotalRequestsSuccessfullyServiced: 1, TotalRequestsDenied: 0}},


### PR DESCRIPTION
## Overview

TestHealthRequestTracker unit test case, expectedStatusCode of `0`, is an invalid WriteHeader code according to go's net/http, i.e. `WriteHeader(0)` panics with `invalid WriteHeader code 0`:

```console
=== RUN   TestHealthRequestTracker
ts=2022-04-21T21:15:19.480190269Z caller=health.go:132 level=debug msg="Health Monitor Stopped"
    health_test.go:160: struct { expectedStatusCode int; expectedStats health.Stats }{expectedStatusCode:0, expectedStats:health.Stats{"TotalRequestsDenied":0, "TotalRequestsReceived":1, "TotalRequestsSuccessfullyServiced":1}}
ts=2022-04-21T21:15:19.480715767Z caller=health.go:120 level=debug msg="Health Monitor Started"
ts=2022-04-21T21:15:19.481352064Z caller=health.go:67 level=error msg="Delegate handler panicked" error="invalid WriteHeader code 0"
    health_test.go:182: 
        	Error Trace:	health_test.go:182
        	Error:      	Not equal: 
        	            	expected: 0
        	            	actual  : 500
        	Test:       	TestHealthRequestTracker
```

https://github.com/golang/go/blob/ff14e844d26090e09aa335d836f737c09a7a0402/src/net/http/httptest/recorder.go#L125-L140

```go
func checkWriteHeaderCode(code int) {
	// Issue 22880: require valid WriteHeader status codes.
	// For now we only enforce that it's three digits.
	// In the future we might block things over 599 (600 and above aren't defined
	// at https://httpwg.org/specs/rfc7231.html#status.codes)
	// and we might block under 200 (once we have more mature 1xx support).
	// But for now any three digits.
	//
	// We used to send "HTTP/1.1 000 0" on the wire in responses but there's
	// no equivalent bogus thing we can realistically send in HTTP/2,
	// so we'll consistently panic instead and help people find their bugs
	// early. (We can't return an error from WriteHeader even if we wanted to.)
	if code < 100 || code > 999 {
		panic(fmt.Sprintf("invalid WriteHeader code %v", code))
	}
}

```

<details>
<summary>Type of Change(s)</summary>

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

</details>

<details>
<summary>Implementation</summary>

https://github.com/denopink/webpa-common/blob/8ac4923af516da55389f9936213a6665499ebe96/device/manager.go
</details>

<details>
<summary>Module Unit Testing: [100% PASSING]</summary>

Passed all package unit tests.

</details>

<details>
<summary>PR Affecting Unit Testing: health_test.go [100% PASSING]</summary>

```console
Running tool: /usr/local/bin/go test -timeout 30s -run ^(TestLifecycle|TestServeHTTP|TestHealthRequestTracker|TestHealthRequestTrackerDelegatePanic)$ github.com/xmidt-org/webpa-common/v2/health

=== RUN   TestLifecycle
ts=2022-04-21T20:38:52.146854Z caller=health.go:120 level=debug msg="Health Monitor Started"
    /Users/ocabal200/Documents/GitHub/denopink/xmidt-org/webpa-common/health/health_test.go:52: verifying AddStatsListener
    /Users/ocabal200/Documents/GitHub/denopink/xmidt-org/webpa-common/health/health_test.go:68: Initial state verified
ts=2022-04-21T20:38:52.146993Z caller=health.go:132 level=debug msg="Health Monitor Stopped"
    /Users/ocabal200/Documents/GitHub/denopink/xmidt-org/webpa-common/health/health_test.go:87: Final state verified
--- PASS: TestLifecycle (0.00s)
=== RUN   TestServeHTTP
ts=2022-04-21T20:38:52.147073Z caller=health.go:120 level=debug msg="Health Monitor Started"
--- PASS: TestServeHTTP (0.00s)
=== RUN   TestHealthRequestTracker
ts=2022-04-21T20:38:52.147474Z caller=health.go:132 level=debug msg="Health Monitor Stopped"
    /Users/ocabal200/Documents/GitHub/denopink/xmidt-org/webpa-common/health/health_test.go:159: struct { expectedStatusCode int; expectedStats health.Stats }{expectedStatusCode:100, expectedStats:health.Stats{"TotalRequestsDenied":0, "TotalRequestsReceived":1, "TotalRequestsSuccessfullyServiced":1}}
ts=2022-04-21T20:38:52.147527Z caller=health.go:120 level=debug msg="Health Monitor Started"
    /Users/ocabal200/Documents/GitHub/denopink/xmidt-org/webpa-common/health/health_test.go:188: actual stats: map[CurrentMemoryUtilizationActive:0 CurrentMemoryUtilizationAlloc:0 CurrentMemoryUtilizationHeapSys:0 MaxMemoryUtilizationActive:0 MaxMemoryUtilizationAlloc:0 MaxMemoryUtilizationHeapSys:0 TotalRequestsDenied:0 TotalRequestsReceived:1 TotalRequestsSuccessfullyServiced:1]
    /Users/ocabal200/Documents/GitHub/denopink/xmidt-org/webpa-common/health/health_test.go:196: PASS:  ServeHTTP(mock.argumentMatcher,*http.Request)
    /Users/ocabal200/Documents/GitHub/denopink/xmidt-org/webpa-common/health/health_test.go:159: struct { expectedStatusCode int; expectedStats health.Stats }{expectedStatusCode:200, expectedStats:health.Stats{"TotalRequestsDenied":0, "TotalRequestsReceived":1, "TotalRequestsSuccessfullyServiced":1}}
ts=2022-04-21T20:38:52.147748Z caller=health.go:120 level=debug msg="Health Monitor Started"
    /Users/ocabal200/Documents/GitHub/denopink/xmidt-org/webpa-common/health/health_test.go:188: actual stats: map[CurrentMemoryUtilizationActive:0 CurrentMemoryUtilizationAlloc:0 CurrentMemoryUtilizationHeapSys:0 MaxMemoryUtilizationActive:0 MaxMemoryUtilizationAlloc:0 MaxMemoryUtilizationHeapSys:0 TotalRequestsDenied:0 TotalRequestsReceived:1 TotalRequestsSuccessfullyServiced:1]
    /Users/ocabal200/Documents/GitHub/denopink/xmidt-org/webpa-common/health/health_test.go:196: PASS:  ServeHTTP(mock.argumentMatcher,*http.Request)
    /Users/ocabal200/Documents/GitHub/denopink/xmidt-org/webpa-common/health/health_test.go:159: struct { expectedStatusCode int; expectedStats health.Stats }{expectedStatusCode:201, expectedStats:health.Stats{"TotalRequestsDenied":0, "TotalRequestsReceived":1, "TotalRequestsSuccessfullyServiced":1}}
ts=2022-04-21T20:38:52.147857Z caller=health.go:120 level=debug msg="Health Monitor Started"
    /Users/ocabal200/Documents/GitHub/denopink/xmidt-org/webpa-common/health/health_test.go:188: actual stats: map[CurrentMemoryUtilizationActive:0 CurrentMemoryUtilizationAlloc:0 CurrentMemoryUtilizationHeapSys:0 MaxMemoryUtilizationActive:0 MaxMemoryUtilizationAlloc:0 MaxMemoryUtilizationHeapSys:0 TotalRequestsDenied:0 TotalRequestsReceived:1 TotalRequestsSuccessfullyServiced:1]
    /Users/ocabal200/Documents/GitHub/denopink/xmidt-org/webpa-common/health/health_test.go:196: PASS:  ServeHTTP(mock.argumentMatcher,*http.Request)
    /Users/ocabal200/Documents/GitHub/denopink/xmidt-org/webpa-common/health/health_test.go:159: struct { expectedStatusCode int; expectedStats health.Stats }{expectedStatusCode:202, expectedStats:health.Stats{"TotalRequestsDenied":0, "TotalRequestsReceived":1, "TotalRequestsSuccessfullyServiced":1}}
ts=2022-04-21T20:38:52.147972Z caller=health.go:120 level=debug msg="Health Monitor Started"
    /Users/ocabal200/Documents/GitHub/denopink/xmidt-org/webpa-common/health/health_test.go:188: actual stats: map[CurrentMemoryUtilizationActive:0 CurrentMemoryUtilizationAlloc:0 CurrentMemoryUtilizationHeapSys:0 MaxMemoryUtilizationActive:0 MaxMemoryUtilizationAlloc:0 MaxMemoryUtilizationHeapSys:0 TotalRequestsDenied:0 TotalRequestsReceived:1 TotalRequestsSuccessfullyServiced:1]
    /Users/ocabal200/Documents/GitHub/denopink/xmidt-org/webpa-common/health/health_test.go:196: PASS:  ServeHTTP(mock.argumentMatcher,*http.Request)
    /Users/ocabal200/Documents/GitHub/denopink/xmidt-org/webpa-common/health/health_test.go:159: struct { expectedStatusCode int; expectedStats health.Stats }{expectedStatusCode:300, expectedStats:health.Stats{"TotalRequestsDenied":0, "TotalRequestsReceived":1, "TotalRequestsSuccessfullyServiced":1}}
ts=2022-04-21T20:38:52.148104Z caller=health.go:120 level=debug msg="Health Monitor Started"
    /Users/ocabal200/Documents/GitHub/denopink/xmidt-org/webpa-common/health/health_test.go:188: actual stats: map[CurrentMemoryUtilizationActive:0 CurrentMemoryUtilizationAlloc:0 CurrentMemoryUtilizationHeapSys:0 MaxMemoryUtilizationActive:0 MaxMemoryUtilizationAlloc:0 MaxMemoryUtilizationHeapSys:0 TotalRequestsDenied:0 TotalRequestsReceived:1 TotalRequestsSuccessfullyServiced:1]
    /Users/ocabal200/Documents/GitHub/denopink/xmidt-org/webpa-common/health/health_test.go:196: PASS:  ServeHTTP(mock.argumentMatcher,*http.Request)
    /Users/ocabal200/Documents/GitHub/denopink/xmidt-org/webpa-common/health/health_test.go:159: struct { expectedStatusCode int; expectedStats health.Stats }{expectedStatusCode:307, expectedStats:health.Stats{"TotalRequestsDenied":0, "TotalRequestsReceived":1, "TotalRequestsSuccessfullyServiced":1}}
ts=2022-04-21T20:38:52.148258Z caller=health.go:120 level=debug msg="Health Monitor Started"
    /Users/ocabal200/Documents/GitHub/denopink/xmidt-org/webpa-common/health/health_test.go:188: actual stats: map[CurrentMemoryUtilizationActive:0 CurrentMemoryUtilizationAlloc:0 CurrentMemoryUtilizationHeapSys:0 MaxMemoryUtilizationActive:0 MaxMemoryUtilizationAlloc:0 MaxMemoryUtilizationHeapSys:0 TotalRequestsDenied:0 TotalRequestsReceived:1 TotalRequestsSuccessfullyServiced:1]
    /Users/ocabal200/Documents/GitHub/denopink/xmidt-org/webpa-common/health/health_test.go:196: PASS:  ServeHTTP(mock.argumentMatcher,*http.Request)
    /Users/ocabal200/Documents/GitHub/denopink/xmidt-org/webpa-common/health/health_test.go:159: struct { expectedStatusCode int; expectedStats health.Stats }{expectedStatusCode:400, expectedStats:health.Stats{"TotalRequestsDenied":1, "TotalRequestsReceived":1, "TotalRequestsSuccessfullyServiced":0}}
ts=2022-04-21T20:38:52.148391Z caller=health.go:120 level=debug msg="Health Monitor Started"
    /Users/ocabal200/Documents/GitHub/denopink/xmidt-org/webpa-common/health/health_test.go:188: actual stats: map[CurrentMemoryUtilizationActive:0 CurrentMemoryUtilizationAlloc:0 CurrentMemoryUtilizationHeapSys:0 MaxMemoryUtilizationActive:0 MaxMemoryUtilizationAlloc:0 MaxMemoryUtilizationHeapSys:0 TotalRequestsDenied:1 TotalRequestsReceived:1 TotalRequestsSuccessfullyServiced:0]
    /Users/ocabal200/Documents/GitHub/denopink/xmidt-org/webpa-common/health/health_test.go:196: PASS:  ServeHTTP(mock.argumentMatcher,*http.Request)
    /Users/ocabal200/Documents/GitHub/denopink/xmidt-org/webpa-common/health/health_test.go:159: struct { expectedStatusCode int; expectedStats health.Stats }{expectedStatusCode:404, expectedStats:health.Stats{"TotalRequestsDenied":1, "TotalRequestsReceived":1, "TotalRequestsSuccessfullyServiced":0}}
ts=2022-04-21T20:38:52.148526Z caller=health.go:120 level=debug msg="Health Monitor Started"
    /Users/ocabal200/Documents/GitHub/denopink/xmidt-org/webpa-common/health/health_test.go:188: actual stats: map[CurrentMemoryUtilizationActive:0 CurrentMemoryUtilizationAlloc:0 CurrentMemoryUtilizationHeapSys:0 MaxMemoryUtilizationActive:0 MaxMemoryUtilizationAlloc:0 MaxMemoryUtilizationHeapSys:0 TotalRequestsDenied:1 TotalRequestsReceived:1 TotalRequestsSuccessfullyServiced:0]
    /Users/ocabal200/Documents/GitHub/denopink/xmidt-org/webpa-common/health/health_test.go:196: PASS:  ServeHTTP(mock.argumentMatcher,*http.Request)
    /Users/ocabal200/Documents/GitHub/denopink/xmidt-org/webpa-common/health/health_test.go:159: struct { expectedStatusCode int; expectedStats health.Stats }{expectedStatusCode:500, expectedStats:health.Stats{"TotalRequestsDenied":1, "TotalRequestsReceived":1, "TotalRequestsSuccessfullyServiced":0}}
ts=2022-04-21T20:38:52.148639Z caller=health.go:120 level=debug msg="Health Monitor Started"
    /Users/ocabal200/Documents/GitHub/denopink/xmidt-org/webpa-common/health/health_test.go:188: actual stats: map[CurrentMemoryUtilizationActive:0 CurrentMemoryUtilizationAlloc:0 CurrentMemoryUtilizationHeapSys:0 MaxMemoryUtilizationActive:0 MaxMemoryUtilizationAlloc:0 MaxMemoryUtilizationHeapSys:0 TotalRequestsDenied:1 TotalRequestsReceived:1 TotalRequestsSuccessfullyServiced:0]
    /Users/ocabal200/Documents/GitHub/denopink/xmidt-org/webpa-common/health/health_test.go:196: PASS:  ServeHTTP(mock.argumentMatcher,*http.Request)
    /Users/ocabal200/Documents/GitHub/denopink/xmidt-org/webpa-common/health/health_test.go:159: struct { expectedStatusCode int; expectedStats health.Stats }{expectedStatusCode:523, expectedStats:health.Stats{"TotalRequestsDenied":1, "TotalRequestsReceived":1, "TotalRequestsSuccessfullyServiced":0}}
ts=2022-04-21T20:38:52.148774Z caller=health.go:120 level=debug msg="Health Monitor Started"
    /Users/ocabal200/Documents/GitHub/denopink/xmidt-org/webpa-common/health/health_test.go:188: actual stats: map[CurrentMemoryUtilizationActive:0 CurrentMemoryUtilizationAlloc:0 CurrentMemoryUtilizationHeapSys:0 MaxMemoryUtilizationActive:0 MaxMemoryUtilizationAlloc:0 MaxMemoryUtilizationHeapSys:0 TotalRequestsDenied:1 TotalRequestsReceived:1 TotalRequestsSuccessfullyServiced:0]
    /Users/ocabal200/Documents/GitHub/denopink/xmidt-org/webpa-common/health/health_test.go:196: PASS:  ServeHTTP(mock.argumentMatcher,*http.Request)
--- PASS: TestHealthRequestTracker (0.00s)
=== RUN   TestHealthRequestTrackerDelegatePanic
ts=2022-04-21T20:38:52.148889Z caller=health.go:120 level=debug msg="Health Monitor Started"
ts=2022-04-21T20:38:52.148963Z caller=health.go:132 level=debug msg="Health Monitor Stopped"
ts=2022-04-21T20:38:52.14898Z caller=health.go:132 level=debug msg="Health Monitor Stopped"
ts=2022-04-21T20:38:52.14899Z caller=health.go:132 level=debug msg="Health Monitor Stopped"
ts=2022-04-21T20:38:52.148951Z caller=health.go:132 level=debug msg="Health Monitor Stopped"
ts=2022-04-21T20:38:52.149003Z caller=health.go:132 level=debug msg="Health Monitor Stopped"
ts=2022-04-21T20:38:52.148999Z caller=health.go:67 level=error msg="Delegate handler panicked" error=expected
ts=2022-04-21T20:38:52.149013Z caller=health.go:132 level=debug msg="Health Monitor Stopped"
ts=2022-04-21T20:38:52.149017Z caller=health.go:132 level=debug msg="Health Monitor Stopped"
ts=2022-04-21T20:38:52.149025Z caller=health.go:132 level=debug msg="Health Monitor Stopped"
ts=2022-04-21T20:38:52.149029Z caller=health.go:132 level=debug msg="Health Monitor Stopped"
ts=2022-04-21T20:38:52.149081Z caller=health.go:132 level=debug msg="Health Monitor Stopped"
    /Users/ocabal200/Documents/GitHub/denopink/xmidt-org/webpa-common/health/health_test.go:236: PASS:  ServeHTTP(mock.argumentMatcher,*http.Request)
--- PASS: TestHealthRequestTrackerDelegatePanic (0.00s)
PASS
ts=2022-04-21T20:38:52.149178Z caller=health.go:132 level=debug msg="Health Monitor Stopped"
ok      github.com/xmidt-org/webpa-common/v2/health     (cached)


> Test run finished at 4/21/2022, 5:06:47 PM <
```

</details>