### PR TITLE
bug: Patch for writePump panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Patch for manager writePump panic. [#595](https://github.com/xmidt-org/webpa-common/pull/595)
 
 ## [v2.0.4]
 - Enforce cipher suites for TLS versions less than 1.3 that are not vulnerable to SWEET32

--- a/device/manager.go
+++ b/device/manager.go
@@ -453,7 +453,6 @@ func (m *manager) writePump(d *device, w WriteCloser, pinger func() error, close
 
 	var (
 		envelope   *envelope
-		encoder    = wrp.NewEncoder(nil, wrp.Msgpack)
 		writeError error
 
 		pingTicker = time.NewTicker(m.pingPeriod)
@@ -518,9 +517,7 @@ func (m *manager) writePump(d *device, w WriteCloser, pinger func() error, close
 			} else {
 				// if the request was in a format other than Msgpack, or if the caller did not pass
 				// Contents, then do the encoding here.
-				encoder.ResetBytes(&frameContents)
-				writeError = encoder.Encode(envelope.request.Message)
-				encoder.ResetBytes(nil)
+				writeError = wrp.NewEncoderBytes(&frameContents, wrp.Msgpack).Encode(envelope.request.Message)
 			}
 
 			if writeError == nil {


### PR DESCRIPTION
## Overview

fixes xmidt-org/talaria#226 where any `/api/v3/device/send` request that doesn't have a `Content-Type: application/msgpack` header, like `Content-Type: application/json`, will trigger a panic:

```console
Exception has occurred: panic

-   

"runtime error: invalid memory address or nil pointer dereference"

Stack:
	4 0x00000000017aeb71 in github.com/ugorji/go/codec.encInBytes at /Users/ocabal200/go/pkg/mod/github.com/ugorji/go/codec@v1.2.6/encode.go:1452
	5 0x00000000017ab4ce in github.com/ugorji/go/codec.(*Encoder).ResetBytes at /Users/ocabal200/go/pkg/mod/github.com/ugorji/go/codec@v1.2.6/encode.go:996
	6 0x000000000183e1fb in github.com/xmidt-org/wrp-go/v3.(*encoderDecorator).ResetBytes at <autogenerated>:1
	7 0x0000000001896944 in github.com/xmidt-org/webpa-common/v2/device.(*manager).writePump at /Users/ocabal200/go/pkg/mod/github.com/xmidt-org/webpa-common/v2@v2.0.1/device/manager.go:523
	8 0x0000000001892ed1 in github.com/xmidt-org/webpa-common/v2/device.(*manager).Connect·dwrap·5 at /Users/ocabal200/go/pkg/mod/github.com/xmidt-org/webpa-common/v2@v2.0.1/device/manager.go:270
```

https://github.com/xmidt-org/webpa-common/blob/6f44bc6864bf17b3bbd6852fc3b2f6a74bb6b403/device/manager.go#L514-L524


Where `envelope.request.Format == wrp.Msgpack` will evaluate to False and `encoder.ResetBytes(nil)` will kick off a panic due to an eventual nil dereferencing caused by ugorji's [`codec.encInBytes`](https://github.com/ugorji/go/blob/b4c725930670fc2d46721b17f4d6974c66fb50c1/codec/encode.go#L1451-L1452) receiving that nil as its `out`


```go
func encInBytes(out *[]byte) (in []byte) {
	in = *out
```

<details>
<summary>Type of Change(s)</summary>

- Bug fix (non-breaking change which fixes an issue)
- All new and existing tests passed.

</details>

<details>
<summary>Implementation</summary>

Collapsed the message encoding to simplify the code since it's only used on none `wrp.Msgpack` messages format request types:
https://github.com/xmidt-org/webpa-common/pull/595/commits/8ac4923af516da55389f9936213a6665499ebe96

</details>

<details>
<summary>Module Unit Testing: [99.9% PASSING]</summary>

Per #594, passed all package unit tests expect for TestHealthRequestTracker 

</details>

<details>
<summary>PR Affecting Unit Testing: manager_test.go [100% PASSING]</summary>

```console
Running tool: /usr/local/bin/go test -timeout 30s -run ^(TestManager|TestGaugeCardinality|TestWRPSourceIsValid)$ github.com/xmidt-org/webpa-common/v2/device

=== RUN   TestManager
=== RUN   TestManager/Connect
=== RUN   TestManager/Connect/MissingDeviceContext
=== RUN   TestManager/Connect/FilterOutDevice
=== RUN   TestManager/Connect/UpgradeError
=== RUN   TestManager/Connect/Visit
=== RUN   TestManager/Connect/IncludesConvey
=== RUN   TestManager/Route
=== RUN   TestManager/Route/BadDestination
{"caller":"manager.go:120","level":"debug","msg":"source check configuration","type":"monitor"}
=== RUN   TestManager/Route/DeviceNotFound
{"caller":"manager.go:120","level":"debug","msg":"source check configuration","type":"monitor"}
=== RUN   TestManager/Disconnect
ts=2022-04-21T19:54:42.160262Z caller=manager.go:120 level=debug msg="source check configuration" type=monitor
ts=2022-04-21T19:54:42.160681Z caller=manager.go:181 level=debug msg="device connect" url=/
ts=2022-04-21T19:54:42.160705Z caller=manager.go:215 level=error id=mac:0000deadbeef msg="missing security information"
ts=2022-04-21T19:54:42.160716Z caller=manager.go:221 level=error id=mac:0000deadbeef msg="bad or missing convey data" error="No convey header present"
ts=2022-04-21T19:54:42.16078Z caller=manager.go:230 level=debug id=mac:0000deadbeef msg="websocket upgrade complete" localAddress=127.0.0.1:56159
ts=2022-04-21T19:54:42.160813Z caller=handlers.go:210 level=debug msg="Connected device" id=mac:0000deadbeef
ts=2022-04-21T19:54:42.160832Z caller=manager.go:452 level=debug id=mac:0000deadbeef msg="writePump starting"
ts=2022-04-21T19:54:42.160851Z caller=manager.go:356 level=debug id=mac:0000deadbeef msg="readPump starting"
ts=2022-04-21T19:54:42.161168Z caller=manager.go:181 level=debug msg="device connect" url=/
ts=2022-04-21T19:54:42.161199Z caller=manager.go:215 level=error id=mac:112233445566 msg="missing security information"
ts=2022-04-21T19:54:42.161207Z caller=manager.go:221 level=error id=mac:112233445566 msg="bad or missing convey data" error="No convey header present"
ts=2022-04-21T19:54:42.16124Z caller=manager.go:230 level=debug id=mac:112233445566 msg="websocket upgrade complete" localAddress=127.0.0.1:56159
ts=2022-04-21T19:54:42.161259Z caller=handlers.go:210 level=debug msg="Connected device" id=mac:112233445566
ts=2022-04-21T19:54:42.161274Z caller=manager.go:452 level=debug id=mac:112233445566 msg="writePump starting"
ts=2022-04-21T19:54:42.161296Z caller=manager.go:356 level=debug id=mac:112233445566 msg="readPump starting"
ts=2022-04-21T19:54:42.161594Z caller=manager.go:181 level=debug msg="device connect" url=/
ts=2022-04-21T19:54:42.161611Z caller=manager.go:215 level=error id=mac:fe881212cdcd msg="missing security information"
ts=2022-04-21T19:54:42.161621Z caller=manager.go:221 level=error id=mac:fe881212cdcd msg="bad or missing convey data" error="No convey header present"
ts=2022-04-21T19:54:42.161674Z caller=manager.go:230 level=debug id=mac:fe881212cdcd msg="websocket upgrade complete" localAddress=127.0.0.1:56159
ts=2022-04-21T19:54:42.161698Z caller=handlers.go:210 level=debug msg="Connected device" id=mac:fe881212cdcd
ts=2022-04-21T19:54:42.161711Z caller=manager.go:452 level=debug id=mac:fe881212cdcd msg="writePump starting"
ts=2022-04-21T19:54:42.161769Z caller=manager.go:356 level=debug id=mac:fe881212cdcd msg="readPump starting"
ts=2022-04-21T19:54:42.162004Z caller=manager.go:181 level=debug msg="device connect" url=/
ts=2022-04-21T19:54:42.162025Z caller=manager.go:215 level=error id=mac:7f551928abcd msg="missing security information"
ts=2022-04-21T19:54:42.162033Z caller=manager.go:221 level=error id=mac:7f551928abcd msg="bad or missing convey data" error="No convey header present"
ts=2022-04-21T19:54:42.162065Z caller=manager.go:230 level=debug id=mac:7f551928abcd msg="websocket upgrade complete" localAddress=127.0.0.1:56159
ts=2022-04-21T19:54:42.162111Z caller=handlers.go:210 level=debug msg="Connected device" id=mac:7f551928abcd
ts=2022-04-21T19:54:42.162118Z caller=manager.go:509 level=debug id=mac:fe881212cdcd msg="explicit shutdown"
ts=2022-04-21T19:54:42.162124Z caller=manager.go:452 level=debug id=mac:7f551928abcd msg="writePump starting"
ts=2022-04-21T19:54:42.162126Z caller=manager.go:356 level=debug id=mac:7f551928abcd msg="readPump starting"
ts=2022-04-21T19:54:42.162135Z caller=manager.go:509 level=debug id=mac:7f551928abcd msg="explicit shutdown"
ts=2022-04-21T19:54:42.162157Z caller=manager.go:509 level=debug id=mac:0000deadbeef msg="explicit shutdown"
ts=2022-04-21T19:54:42.162165Z caller=manager.go:509 level=debug id=mac:112233445566 msg="explicit shutdown"
ts=2022-04-21T19:54:42.162162Z caller=manager.go:373 level=error id=mac:7f551928abcd msg="read error" error="read tcp 127.0.0.1:56159->127.0.0.1:56163: use of closed network connection"
ts=2022-04-21T19:54:42.16218Z caller=manager.go:294 level=error id=mac:fe881212cdcd msg="Closed device connection" closeError="close tcp 127.0.0.1:56159->127.0.0.1:56162: use of closed network connection" reasonError=null reason=write-error finalStatistics="{\"bytesSent\": 0, \"messagesSent\": 0, \"bytesReceived\": 0, \"messagesReceived\": 0, \"duplications\": 0, \"connectedAt\": \"2022-04-21T19:54:42.161604Z\", \"upTime\": \"567µs\"}"
ts=2022-04-21T19:54:42.162149Z caller=manager.go:373 level=error id=mac:fe881212cdcd msg="read error" error="read tcp 127.0.0.1:56159->127.0.0.1:56162: use of closed network connection"
ts=2022-04-21T19:54:42.162199Z caller=manager.go:373 level=error id=mac:0000deadbeef msg="read error" error="read tcp 127.0.0.1:56159->127.0.0.1:56160: use of closed network connection"
ts=2022-04-21T19:54:42.162214Z caller=manager.go:511 level=debug id=mac:fe881212cdcd msg="writePump exiting"
ts=2022-04-21T19:54:42.162194Z caller=manager.go:373 level=error id=mac:112233445566 msg="read error" error="read tcp 127.0.0.1:56159->127.0.0.1:56161: use of closed network connection"
ts=2022-04-21T19:54:42.162217Z caller=manager.go:294 level=error id=mac:0000deadbeef msg="Closed device connection" closeError="close tcp 127.0.0.1:56159->127.0.0.1:56160: use of closed network connection" reasonError=null reason=write-error finalStatistics="{\"bytesSent\": 0, \"messagesSent\": 0, \"bytesReceived\": 0, \"messagesReceived\": 0, \"duplications\": 0, \"connectedAt\": \"2022-04-21T19:54:42.160698Z\", \"upTime\": \"1.512ms\"}"
ts=2022-04-21T19:54:42.16221Z caller=manager.go:294 level=error id=mac:7f551928abcd msg="Closed device connection" closeError="close tcp 127.0.0.1:56159->127.0.0.1:56163: use of closed network connection" reasonError=null reason=readerror finalStatistics="{\"bytesSent\": 0, \"messagesSent\": 0, \"bytesReceived\": 0, \"messagesReceived\": 0, \"duplications\": 0, \"connectedAt\": \"2022-04-21T19:54:42.162014Z\", \"upTime\": \"169µs\"}"
ts=2022-04-21T19:54:42.162227Z caller=manager.go:374 level=debug id=mac:fe881212cdcd msg="readPump exiting"
ts=2022-04-21T19:54:42.162235Z caller=manager.go:511 level=debug id=mac:0000deadbeef msg="writePump exiting"
ts=2022-04-21T19:54:42.16224Z caller=manager.go:374 level=debug id=mac:7f551928abcd msg="readPump exiting"
ts=2022-04-21T19:54:42.162248Z caller=manager.go:374 level=debug id=mac:0000deadbeef msg="readPump exiting"
ts=2022-04-21T19:54:42.162254Z caller=manager.go:511 level=debug id=mac:7f551928abcd msg="writePump exiting"
ts=2022-04-21T19:54:42.162246Z caller=manager.go:294 level=error id=mac:112233445566 msg="Closed device connection" closeError="close tcp 127.0.0.1:56159->127.0.0.1:56161: use of closed network connection" reasonError=null reason=readerror finalStatistics="{\"bytesSent\": 0, \"messagesSent\": 0, \"bytesReceived\": 0, \"messagesReceived\": 0, \"duplications\": 0, \"connectedAt\": \"2022-04-21T19:54:42.161185Z\", \"upTime\": \"1.041ms\"}"
ts=2022-04-21T19:54:42.162281Z caller=manager.go:374 level=debug id=mac:112233445566 msg="readPump exiting"
ts=2022-04-21T19:54:42.16229Z caller=manager.go:511 level=debug id=mac:112233445566 msg="writePump exiting"
=== RUN   TestManager/DisconnectIf
ts=2022-04-21T19:54:42.162399Z caller=manager.go:120 level=debug msg="source check configuration" type=monitor
ts=2022-04-21T19:54:42.162749Z caller=manager.go:181 level=debug msg="device connect" url=/
ts=2022-04-21T19:54:42.16277Z caller=manager.go:215 level=error id=mac:0000deadbeef msg="missing security information"
ts=2022-04-21T19:54:42.162779Z caller=manager.go:221 level=error id=mac:0000deadbeef msg="bad or missing convey data" error="No convey header present"
ts=2022-04-21T19:54:42.162818Z caller=manager.go:230 level=debug id=mac:0000deadbeef msg="websocket upgrade complete" localAddress=127.0.0.1:56164
ts=2022-04-21T19:54:42.162843Z caller=handlers.go:210 level=debug msg="Connected device" id=mac:0000deadbeef
ts=2022-04-21T19:54:42.162855Z caller=manager.go:452 level=debug id=mac:0000deadbeef msg="writePump starting"
ts=2022-04-21T19:54:42.162889Z caller=manager.go:356 level=debug id=mac:0000deadbeef msg="readPump starting"
ts=2022-04-21T19:54:42.163171Z caller=manager.go:181 level=debug msg="device connect" url=/
ts=2022-04-21T19:54:42.163186Z caller=manager.go:215 level=error id=mac:112233445566 msg="missing security information"
ts=2022-04-21T19:54:42.163193Z caller=manager.go:221 level=error id=mac:112233445566 msg="bad or missing convey data" error="No convey header present"
ts=2022-04-21T19:54:42.163226Z caller=manager.go:230 level=debug id=mac:112233445566 msg="websocket upgrade complete" localAddress=127.0.0.1:56164
ts=2022-04-21T19:54:42.163242Z caller=handlers.go:210 level=debug msg="Connected device" id=mac:112233445566
ts=2022-04-21T19:54:42.163252Z caller=manager.go:452 level=debug id=mac:112233445566 msg="writePump starting"
ts=2022-04-21T19:54:42.163261Z caller=manager.go:356 level=debug id=mac:112233445566 msg="readPump starting"
ts=2022-04-21T19:54:42.163665Z caller=manager.go:181 level=debug msg="device connect" url=/
ts=2022-04-21T19:54:42.163699Z caller=manager.go:215 level=error id=mac:fe881212cdcd msg="missing security information"
ts=2022-04-21T19:54:42.163712Z caller=manager.go:221 level=error id=mac:fe881212cdcd msg="bad or missing convey data" error="No convey header present"
ts=2022-04-21T19:54:42.163766Z caller=manager.go:230 level=debug id=mac:fe881212cdcd msg="websocket upgrade complete" localAddress=127.0.0.1:56164
ts=2022-04-21T19:54:42.163785Z caller=handlers.go:210 level=debug msg="Connected device" id=mac:fe881212cdcd
ts=2022-04-21T19:54:42.163796Z caller=manager.go:452 level=debug id=mac:fe881212cdcd msg="writePump starting"
ts=2022-04-21T19:54:42.163828Z caller=manager.go:356 level=debug id=mac:fe881212cdcd msg="readPump starting"
ts=2022-04-21T19:54:42.16408Z caller=manager.go:181 level=debug msg="device connect" url=/
ts=2022-04-21T19:54:42.164095Z caller=manager.go:215 level=error id=mac:7f551928abcd msg="missing security information"
ts=2022-04-21T19:54:42.164102Z caller=manager.go:221 level=error id=mac:7f551928abcd msg="bad or missing convey data" error="No convey header present"
ts=2022-04-21T19:54:42.164137Z caller=manager.go:230 level=debug id=mac:7f551928abcd msg="websocket upgrade complete" localAddress=127.0.0.1:56164
ts=2022-04-21T19:54:42.164155Z caller=handlers.go:210 level=debug msg="Connected device" id=mac:7f551928abcd
ts=2022-04-21T19:54:42.164165Z caller=manager.go:452 level=debug id=mac:7f551928abcd msg="writePump starting"
ts=2022-04-21T19:54:42.164171Z caller=manager.go:356 level=debug id=mac:7f551928abcd msg="readPump starting"
ts=2022-04-21T19:54:42.164177Z caller=manager.go:509 level=debug id=mac:0000deadbeef msg="explicit shutdown"
ts=2022-04-21T19:54:42.16421Z caller=manager.go:373 level=error id=mac:0000deadbeef msg="read error" error="read tcp 127.0.0.1:56164->127.0.0.1:56165: use of closed network connection"
ts=2022-04-21T19:54:42.164224Z caller=manager.go:294 level=error id=mac:0000deadbeef msg="Closed device connection" closeError="close tcp 127.0.0.1:56164->127.0.0.1:56165: use of closed network connection" reasonError=null reason=readerror finalStatistics="{\"bytesSent\": 0, \"messagesSent\": 0, \"bytesReceived\": 0, \"messagesReceived\": 0, \"duplications\": 0, \"connectedAt\": \"2022-04-21T19:54:42.162761Z\", \"upTime\": \"1.457ms\"}"
ts=2022-04-21T19:54:42.164238Z caller=manager.go:374 level=debug id=mac:0000deadbeef msg="readPump exiting"
ts=2022-04-21T19:54:42.164245Z caller=manager.go:511 level=debug id=mac:0000deadbeef msg="writePump exiting"
ts=2022-04-21T19:54:42.164256Z caller=manager.go:509 level=debug id=mac:112233445566 msg="explicit shutdown"
ts=2022-04-21T19:54:42.164293Z caller=manager.go:373 level=error id=mac:112233445566 msg="read error" error="read tcp 127.0.0.1:56164->127.0.0.1:56166: use of closed network connection"
ts=2022-04-21T19:54:42.164306Z caller=manager.go:294 level=error id=mac:112233445566 msg="Closed device connection" closeError="close tcp 127.0.0.1:56164->127.0.0.1:56166: use of closed network connection" reasonError=null reason=readerror finalStatistics="{\"bytesSent\": 0, \"messagesSent\": 0, \"bytesReceived\": 0, \"messagesReceived\": 0, \"duplications\": 0, \"connectedAt\": \"2022-04-21T19:54:42.163179Z\", \"upTime\": \"1.122ms\"}"
ts=2022-04-21T19:54:42.164344Z caller=manager.go:511 level=debug id=mac:112233445566 msg="writePump exiting"
ts=2022-04-21T19:54:42.164318Z caller=manager.go:374 level=debug id=mac:112233445566 msg="readPump exiting"
ts=2022-04-21T19:54:42.164351Z caller=manager.go:509 level=debug id=mac:fe881212cdcd msg="explicit shutdown"
ts=2022-04-21T19:54:42.164394Z caller=manager.go:373 level=error id=mac:fe881212cdcd msg="read error" error="read tcp 127.0.0.1:56164->127.0.0.1:56167: use of closed network connection"
ts=2022-04-21T19:54:42.164456Z caller=manager.go:294 level=error id=mac:fe881212cdcd msg="Closed device connection" closeError="close tcp 127.0.0.1:56164->127.0.0.1:56167: use of closed network connection" reasonError=null reason=readerror finalStatistics="{\"bytesSent\": 0, \"messagesSent\": 0, \"bytesReceived\": 0, \"messagesReceived\": 0, \"duplications\": 0, \"connectedAt\": \"2022-04-21T19:54:42.163683Z\", \"upTime\": \"740µs\"}"
ts=2022-04-21T19:54:42.164505Z caller=manager.go:374 level=debug id=mac:fe881212cdcd msg="readPump exiting"
ts=2022-04-21T19:54:42.164518Z caller=manager.go:511 level=debug id=mac:fe881212cdcd msg="writePump exiting"
ts=2022-04-21T19:54:42.164521Z caller=manager.go:509 level=debug id=mac:7f551928abcd msg="explicit shutdown"
ts=2022-04-21T19:54:42.164585Z caller=manager.go:373 level=error id=mac:7f551928abcd msg="read error" error="read tcp 127.0.0.1:56164->127.0.0.1:56168: use of closed network connection"
ts=2022-04-21T19:54:42.164609Z caller=manager.go:294 level=error id=mac:7f551928abcd msg="Closed device connection" closeError="close tcp 127.0.0.1:56164->127.0.0.1:56168: use of closed network connection" reasonError=null reason=write-error finalStatistics="{\"bytesSent\": 0, \"messagesSent\": 0, \"bytesReceived\": 0, \"messagesReceived\": 0, \"duplications\": 0, \"connectedAt\": \"2022-04-21T19:54:42.164088Z\", \"upTime\": \"512µs\"}"
ts=2022-04-21T19:54:42.164637Z caller=manager.go:511 level=debug id=mac:7f551928abcd msg="writePump exiting"
ts=2022-04-21T19:54:42.164645Z caller=manager.go:374 level=debug id=mac:7f551928abcd msg="readPump exiting"
--- PASS: TestManager (0.01s)
    --- PASS: TestManager/Connect (0.00s)
        --- PASS: TestManager/Connect/MissingDeviceContext (0.00s)
        --- PASS: TestManager/Connect/FilterOutDevice (0.00s)
        --- PASS: TestManager/Connect/UpgradeError (0.00s)
        --- PASS: TestManager/Connect/Visit (0.00s)
        --- PASS: TestManager/Connect/IncludesConvey (0.00s)
    --- PASS: TestManager/Route (0.00s)
        --- PASS: TestManager/Route/BadDestination (0.00s)
        --- PASS: TestManager/Route/DeviceNotFound (0.00s)
    --- PASS: TestManager/Disconnect (0.00s)
    --- PASS: TestManager/DisconnectIf (0.00s)
=== RUN   TestGaugeCardinality
{"fqn":"test_test_device_count","level":"debug","msg":"merging metric","name":"device_count","namespace":"test","subsystem":"test","type":"gauge"}
{"fqn":"test_test_duplicate_count","level":"debug","msg":"merging metric","name":"duplicate_count","namespace":"test","subsystem":"test","type":"counter"}
{"fqn":"test_test_request_response_count","level":"debug","msg":"merging metric","name":"request_response_count","namespace":"test","subsystem":"test","type":"counter"}
{"fqn":"test_test_ping_count","level":"debug","msg":"merging metric","name":"ping_count","namespace":"test","subsystem":"test","type":"counter"}
{"fqn":"test_test_pong_count","level":"debug","msg":"merging metric","name":"pong_count","namespace":"test","subsystem":"test","type":"counter"}
{"fqn":"test_test_connect_count","level":"debug","msg":"merging metric","name":"connect_count","namespace":"test","subsystem":"test","type":"counter"}
{"fqn":"test_test_disconnect_count","level":"debug","msg":"merging metric","name":"disconnect_count","namespace":"test","subsystem":"test","type":"counter"}
{"fqn":"test_test_device_limit_reached_count","level":"debug","msg":"merging metric","name":"device_limit_reached_count","namespace":"test","subsystem":"test","type":"counter"}
{"fqn":"test_test_hardware_model","level":"debug","msg":"merging metric","name":"hardware_model","namespace":"test","subsystem":"test","type":"gauge"}
{"fqn":"test_test_wrp_source_check","level":"debug","msg":"merging metric","name":"wrp_source_check","namespace":"test","subsystem":"test","type":"counter"}
{"fqn":"test_test_device_count","level":"debug","msg":"registering merged metric","name":"device_count","namespace":"test","subsystem":"test","type":"gauge"}
{"fqn":"test_test_duplicate_count","level":"debug","msg":"registering merged metric","name":"duplicate_count","namespace":"test","subsystem":"test","type":"counter"}
{"fqn":"test_test_request_response_count","level":"debug","msg":"registering merged metric","name":"request_response_count","namespace":"test","subsystem":"test","type":"counter"}
{"fqn":"test_test_disconnect_count","level":"debug","msg":"registering merged metric","name":"disconnect_count","namespace":"test","subsystem":"test","type":"counter"}
{"fqn":"test_test_device_limit_reached_count","level":"debug","msg":"registering merged metric","name":"device_limit_reached_count","namespace":"test","subsystem":"test","type":"counter"}
{"fqn":"test_test_hardware_model","level":"debug","msg":"registering merged metric","name":"hardware_model","namespace":"test","subsystem":"test","type":"gauge"}
{"fqn":"test_test_ping_count","level":"debug","msg":"registering merged metric","name":"ping_count","namespace":"test","subsystem":"test","type":"counter"}
{"fqn":"test_test_pong_count","level":"debug","msg":"registering merged metric","name":"pong_count","namespace":"test","subsystem":"test","type":"counter"}
{"fqn":"test_test_connect_count","level":"debug","msg":"registering merged metric","name":"connect_count","namespace":"test","subsystem":"test","type":"counter"}
{"fqn":"test_test_wrp_source_check","level":"debug","msg":"registering merged metric","name":"wrp_source_check","namespace":"test","subsystem":"test","type":"counter"}
{"caller":"manager.go:120","level":"debug","msg":"source check configuration","type":"monitor"}
--- PASS: TestGaugeCardinality (0.00s)
=== RUN   TestWRPSourceIsValid
=== RUN   TestWRPSourceIsValid/EmptySource
ts=2022-04-21T19:54:42.167261Z id=mac:112233445566 msg="WRP source was empty" trustLevel=0
ts=2022-04-21T19:54:42.167308Z id=mac:112233445566 msg="WRP source was empty" trustLevel=0
=== RUN   TestWRPSourceIsValid/ParseFailure
ts=2022-04-21T19:54:42.167372Z id=mac:112233445566 msg="Failed to parse ID from WRP source" trustLevel=0
ts=2022-04-21T19:54:42.167385Z id=mac:112233445566 msg="Failed to parse ID from WRP source" trustLevel=0
=== RUN   TestWRPSourceIsValid/IDMismatch
ts=2022-04-21T19:54:42.167422Z id=mac:112233445566 msg="ID in WRP source does not match device's ID" spoofedID=mac:665544332211 trustLevel=0
ts=2022-04-21T19:54:42.167445Z id=mac:112233445566 msg="ID in WRP source does not match device's ID" spoofedID=mac:665544332211 trustLevel=0
=== RUN   TestWRPSourceIsValid/IDMatch
--- PASS: TestWRPSourceIsValid (0.00s)
    --- PASS: TestWRPSourceIsValid/EmptySource (0.00s)
    --- PASS: TestWRPSourceIsValid/ParseFailure (0.00s)
    --- PASS: TestWRPSourceIsValid/IDMismatch (0.00s)
    --- PASS: TestWRPSourceIsValid/IDMatch (0.00s)
PASS
ok      github.com/xmidt-org/webpa-common/v2/device     0.361s


> Test run finished at 4/21/2022, 3:54:42 PM <
```

</details>



## Local Test
Ran the simulator & talaria locally

Tested the patch with the following:
```console
curl -v --location --request POST 'localhost:6200/api/v3/device/send' \
--header 'Authorization: Basic ${AUTH}' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--data-raw '{
"msg_type":3,
"content_type":"application/json",
"source":"dns:me",
"dest":"mac:112233445566",
"transaction_uuid":"1234567890",
"payload":"eyJjb21tYW5kIjoiR0VUIiwibmFtZXMiOlsiU29tZXRoaW5nIl19",
"partner_ids":["comcast"]
}'

// Output:

Note: Unnecessary use of -X or --request, POST is already inferred.
*   Trying ::1:6200...
* Connected to localhost (::1) port 6200 (#0)
> POST /api/v3/device/send HTTP/1.1
> Host: localhost:6200
> User-Agent: curl/7.77.0
> Authorization: Basic ${AUTH}
> Content-Type: application/json
> Accept: application/json
> Content-Length: 287
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Content-Length: 648
< Content-Type: application/json
< X-Talaria-Build: 0.1.4
< X-Talaria-Flavor: mint
< X-Talaria-Region: east
< X-Talaria-Server: talaria
< X-Talaria-Start-Time: 21 Apr 22 16:23 UTC
< Date: Thu, 21 Apr 2022 16:42:49 GMT
< 
* Connection #0 to host localhost left intact
{"msg_type":3,"source":"mac:112233445566","dest":"dns:me","transaction_uuid":"1234567890","content_type":"application/octet-stream","metadata":{"partner-id":"comcast","hw-serial-number":"mock-rdkb-simulator","hw-manufacturer":"Example","hw-mac":"112233445566","hw-last-reboot-reason":"unknown","fw-name":"mock-rdkb-firmware","boot-time":"1650557221","webpa-last-reconnect-reason":"webpa_process_starts","webpa-protocol":"PARODUS-2.0-1.1.4-6-gad2d43b","hw-model":"aker-testing","webpa-interface-used":"eth0","webpa-uuid":"1234567-345456546"},"payload":"eyJzdGF0dXNDb2RlIjo1MzEsIm1lc3NhZ2UiOiJTZXJ2aWNlIFVuYXZhaWxhYmxlIn0=","partner_ids":["unknown"]}
```
