### PR TITLE
JWK Migration Release v2.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [v2.0.7-dev.1]
+## [v2.0.7]
 - Update dependencies. [603](https://github.com/xmidt-org/webpa-common/pull/603)
   - [github.com/prometheus/client_golang v1.12.2 CVE-2022-21698 no patch available](https://github.com/advisories/GHSA-cg3q-j54f-5p7p)
   - [github.com/prometheus/client_golang v1.12.2 CVE-2022-21698 no patch available](https://github.com/prometheus/client_golang/security/advisories/GHSA-cg3q-j54f-5p7p)
@@ -245,9 +245,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - The first official release. We will be better about documenting changes 
    moving forward.
 
-[Unreleased]: https://github.com/xmidt-org/webpa-common/compare/v2.0.7-dev.2...HEAD
-[v2.0.7-dev.2]: https://github.com/xmidt-org/webpa-common/compare/v2.0.7-dev.1...v2.0.7-dev.2
-[v2.0.7-dev.1]: https://github.com/xmidt-org/webpa-common/compare/v2.0.6...v2.0.7-dev.1
+[Unreleased]: https://github.com/xmidt-org/webpa-common/compare/v2.0.7...HEAD
+[v2.0.7]: https://github.com/xmidt-org/webpa-common/compare/v2.0.6...v2.0.7
 [v2.0.6]: https://github.com/xmidt-org/webpa-common/compare/v2.0.5...v2.0.6
 [v2.0.5]: https://github.com/xmidt-org/webpa-common/compare/v2.0.4...v2.0.5
 [v2.0.4]: https://github.com/xmidt-org/webpa-common/compare/v2.0.3...v2.0.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ## [v2.0.7]
+- Dependency update, note vulnerabilities
+  - Introduces new vuln https://www.mend.io/vulnerability-database/CVE-2022-29526
 - Update dependencies. [603](https://github.com/xmidt-org/webpa-common/pull/603)
   - [github.com/prometheus/client_golang v1.12.2 CVE-2022-21698 no patch available](https://github.com/advisories/GHSA-cg3q-j54f-5p7p)
   - [github.com/prometheus/client_golang v1.12.2 CVE-2022-21698 no patch available](https://github.com/prometheus/client_golang/security/advisories/GHSA-cg3q-j54f-5p7p)
@@ -17,7 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update Argus & Bascule for jwk migration
 - Dependency update, note vulnerabilities
   - Introduces new vuln https://www.mend.io/vulnerability-database/CVE-2022-29526
-  
+
 ## [v2.0.6]
 - Patch for manager writePump panic. [#595](https://github.com/xmidt-org/webpa-common/pull/595)
 


### PR DESCRIPTION
What's included:

- Dependency update, note vulnerabilities
  - Introduces new vuln https://www.mend.io/vulnerability-database/CVE-2022-29526
- Update dependencies. [603](https://github.com/xmidt-org/webpa-common/pull/603)
  - [github.com/prometheus/client_golang v1.12.2 CVE-2022-21698 no patch available](https://github.com/advisories/GHSA-cg3q-j54f-5p7p)
  - [github.com/prometheus/client_golang v1.12.2 CVE-2022-21698 no patch available](https://github.com/prometheus/client_golang/security/advisories/GHSA-cg3q-j54f-5p7p)
  - [github.com/hashicorp/consul/api v1.13.0 CVE-2022-29153 patched versions 1.9.17 1.10.10 1.11.5](https://github.com/advisories/GHSA-q6h7-4qgw-2j9p)
  - guardrails says github.com/gorilla/websocket v1.5.0 has a high vulnerability but no vulnerabilities have been filed atm
  - [github.com/gorilla/sessions v1.2.1 CWE-613 no patch available](https://cwe.mitre.org/data/definitions/613.html)
- Fixed error string sent in response when device ID can't be parsed. [#599](https://github.com/xmidt-org/webpa-common/pull/599)
- Update Argus & Bascule for jwk migration