### PR TITLE
patch: remove forloop var pass by reference

### DIFF
--- a/service/consul/environment.go
+++ b/service/consul/environment.go
@@ -167,7 +167,7 @@ func newRegistrars(l *adapter.Logger, registrationScheme string, c gokitconsul.C
 		rid := zap.String("id", registration.ID)
 		in := zap.String("instance", instance)
 		l.Logger = l.Logger.With(rid, in)
-		consulRegistrar, err = NewRegistrar(c, u, &registration, l)
+		consulRegistrar, err = NewRegistrar(c, u, registration, l)
 		if err != nil {
 			return
 		}

--- a/service/consul/registrar.go
+++ b/service/consul/registrar.go
@@ -130,7 +130,7 @@ type ttlRegistrar struct {
 }
 
 // NewRegistrar creates an sd.Registrar, binding any TTL checks to the Register/Deregister lifecycle as needed.
-func NewRegistrar(c gokitconsul.Client, u ttlUpdater, r *api.AgentServiceRegistration, logger *adapter.Logger) (sd.Registrar, error) {
+func NewRegistrar(c gokitconsul.Client, u ttlUpdater, r api.AgentServiceRegistration, logger *adapter.Logger) (sd.Registrar, error) {
 	var (
 		ttlChecks []ttlCheck
 		err       error
@@ -148,7 +148,7 @@ func NewRegistrar(c gokitconsul.Client, u ttlUpdater, r *api.AgentServiceRegistr
 		}
 	}
 
-	var registrar sd.Registrar = gokitconsul.NewRegistrar(c, r, logger)
+	var registrar sd.Registrar = gokitconsul.NewRegistrar(c, &r, logger)
 
 	// decorate the given registrar if we have any TTL checks
 	if len(ttlChecks) > 0 {

--- a/service/consul/registrar_test.go
+++ b/service/consul/registrar_test.go
@@ -39,7 +39,7 @@ func testNewRegistrarNoChecks(t *testing.T) {
 		ttlUpdater    = new(mockTTLUpdater)
 		tickerFactory = prepareMockTickerFactory()
 
-		registration = &api.AgentServiceRegistration{
+		registration = api.AgentServiceRegistration{
 			ID:      "service1",
 			Address: "somehost.com",
 			Port:    1111,
@@ -80,7 +80,7 @@ func testNewRegistrarNoTTL(t *testing.T) {
 		ttlUpdater    = new(mockTTLUpdater)
 		tickerFactory = prepareMockTickerFactory()
 
-		registration = &api.AgentServiceRegistration{
+		registration = api.AgentServiceRegistration{
 			ID:      "service1",
 			Address: "somehost.com",
 			Port:    1111,
@@ -131,7 +131,7 @@ func testNewRegistrarCheckMalformedTTL(t *testing.T) {
 		ttlUpdater    = new(mockTTLUpdater)
 		tickerFactory = prepareMockTickerFactory()
 
-		registration = &api.AgentServiceRegistration{
+		registration = api.AgentServiceRegistration{
 			ID:      "service1",
 			Address: "somehost.com",
 			Port:    1111,
@@ -161,7 +161,7 @@ func testNewRegistrarCheckTTLTooSmall(t *testing.T) {
 		ttlUpdater    = new(mockTTLUpdater)
 		tickerFactory = prepareMockTickerFactory()
 
-		registration = &api.AgentServiceRegistration{
+		registration = api.AgentServiceRegistration{
 			ID:      "service1",
 			Address: "somehost.com",
 			Port:    1111,
@@ -191,7 +191,7 @@ func testNewRegistrarChecksMalformedTTL(t *testing.T) {
 		ttlUpdater    = new(mockTTLUpdater)
 		tickerFactory = prepareMockTickerFactory()
 
-		registration = &api.AgentServiceRegistration{
+		registration = api.AgentServiceRegistration{
 			ID:      "service1",
 			Address: "somehost.com",
 			Port:    1111,
@@ -223,7 +223,7 @@ func testNewRegistrarChecksTTLTooSmall(t *testing.T) {
 		ttlUpdater    = new(mockTTLUpdater)
 		tickerFactory = prepareMockTickerFactory()
 
-		registration = &api.AgentServiceRegistration{
+		registration = api.AgentServiceRegistration{
 			ID:      "service1",
 			Address: "somehost.com",
 			Port:    1111,
@@ -272,7 +272,7 @@ func testNewRegistrarTTL(t *testing.T) {
 			close(update2Done)
 		}
 
-		registration = &api.AgentServiceRegistration{
+		registration = api.AgentServiceRegistration{
 			ID:      "service1",
 			Address: "somehost.com",
 			Port:    1111,


### PR DESCRIPTION
Sucessful `testVerifyEnviromentRegistrars` with patch:

```
=== RUN   TestNewEnvironment
=== RUN   TestNewEnvironment/Verify_Multi_Registrar_Environment
--- PASS: TestNewEnvironment/Verify_Multi_Registrar_Environment (0.00s)
--- PASS: TestNewEnvironment (0.00s)
PASS
ok      github.com/xmidt-org/webpa-common/v2/service/consul     0.019s

```

Failure `testVerifyEnviromentRegistrars` with forloop bug:

```
panic:
assert: mock: The method has been called over 1 times.
        Either do one more Mock.On("Register").Return(...), or remove extra call.
        This call was unexpected:
                Register(*api.AgentServiceRegistration)
                0: &api.AgentServiceRegistration{Kind:"", ID:"api:deadbeef", Name:"deadbeef-api", Tags:[]string{"role=deadbeef, region=1"}, Port:443, Address:"deadbeef.com", SocketPath:"", TaggedAddresses:map[string]api.ServiceAddress(nil), EnableTagOverride:false, Meta:map[string]string(nil), Weights:(*api.AgentWeights)(nil), Check:(*api.AgentServiceCheck)(nil), Checks:api.AgentServiceChecks(nil), Proxy:(*api.AgentServiceConnectProxyConfig)(nil), Connect:(*api.AgentServiceConnect)(nil), Namespace:"", Partition:"", Locality:(*api.Locality)(nil)}
        at: [/Users/odc/Documents/GitHub/xmidt-org/webpa-common/service/consul/mocks_test.go:60 /Users/odc/go/pkg/mod/github.com/go-kit/kit@v0.13.0/sd/consul/registrar.go:30 /Users/odc/Documents/GitHub/xmidt-org/webpa-common/service/registrars.go:13 /Users/odc/Documents/GitHub/xmidt-org/webpa-common/service/environment.go:198 /Users/odc/Documents/GitHub/xmidt-org/webpa-common/service/consul/environment_test.go:191] [recovered]
        panic:
assert: mock: The method has been called over 1 times.
        Either do one more Mock.On("Register").Return(...), or remove extra call.
        This call was unexpected:
                Register(*api.AgentServiceRegistration)
                0: &api.AgentServiceRegistration{Kind:"", ID:"api:deadbeef", Name:"deadbeef-api", Tags:[]string{"role=deadbeef, region=1"}, Port:443, Address:"deadbeef.com", SocketPath:"", TaggedAddresses:map[string]api.ServiceAddress(nil), EnableTagOverride:false, Meta:map[string]string(nil), Weights:(*api.AgentWeights)(nil), Check:(*api.AgentServiceCheck)(nil), Checks:api.AgentServiceChecks(nil), Proxy:(*api.AgentServiceConnectProxyConfig)(nil), Connect:(*api.AgentServiceConnect)(nil), Namespace:"", Partition:"", Locality:(*api.Locality)(nil)}
        at: [/Users/odc/Documents/GitHub/xmidt-org/webpa-common/service/consul/mocks_test.go:60 /Users/odc/go/pkg/mod/github.com/go-kit/kit@v0.13.0/sd/consul/registrar.go:30 /Users/odc/Documents/GitHub/xmidt-org/webpa-common/service/registrars.go:13 /Users/odc/Documents/GitHub/xmidt-org/webpa-common/service/environment.go:198 /Users/odc/Documents/GitHub/xmidt-org/webpa-common/service/consul/environment_test.go:191]
```