### PR TITLE
patch: service hashing should use the host component from the registered consul url

### DIFF
--- a/service/accessorFactory.go
+++ b/service/accessorFactory.go
@@ -1,6 +1,9 @@
 package service
 
 import (
+	"fmt"
+	"net/url"
+
 	"github.com/billhathaway/consistentHash"
 	"github.com/xmidt-org/webpa-common/v2/xhttp/gate"
 )
@@ -11,13 +14,51 @@ const DefaultVnodeCount = 211
 // of nodes and turn them into an Accessor.
 type AccessorFactory func([]string) Accessor
 
+type hostHasher struct {
+	hasher    *consistentHash.ConsistentHash
+	hostToURL map[string]string
+}
+
+// Add adds a server url to the consistentHash.
+// Note, Add expects a valid url with a schema and hostname
+func (h *hostHasher) Add(s string) {
+	u, err := url.Parse(s)
+	if err != nil {
+		panic(fmt.Sprintf("failed to parse url `%s`: %s", s, err))
+	}
+	if u.Scheme == "" || u.Host == "" {
+		panic(fmt.Sprintf("expected a schema and host: `%s`", s))
+	}
+
+	h.hasher.Add(u.Hostname())
+	h.hostToURL[u.Hostname()] = u.String()
+}
+
+// Get fetches the server url associated with a particular key.
+func (h *hostHasher) Get(key []byte) (string, error) {
+	host, err := h.hasher.Get(key)
+	if err != nil {
+		return "", err
+	}
+
+	return h.hostToURL[host], nil
+}
+
+func newHostHasher(vnodeCount int) *hostHasher {
+	hasher := consistentHash.New()
+	hasher.SetVnodeCount(vnodeCount)
+	return &hostHasher{
+		hasher:    hasher,
+		hostToURL: map[string]string{},
+	}
+}
+
 func newConsistentAccessor(vnodeCount int, instances []string) Accessor {
 	if len(instances) == 0 {
 		return emptyAccessor{}
 	}
 
-	hasher := consistentHash.New()
-	hasher.SetVnodeCount(vnodeCount)
+	hasher := newHostHasher(vnodeCount)
 	for _, i := range instances {
 		hasher.Add(i)
 	}

--- a/service/accessorFactory_test.go
+++ b/service/accessorFactory_test.go
@@ -30,13 +30,13 @@ func testNewConsistentAccessorNonEmpty(t *testing.T) {
 		assert  = assert.New(t)
 		require = require.New(t)
 
-		a = newConsistentAccessor(123, []string{"an instance"})
+		a = newConsistentAccessor(123, []string{"https://example.com"})
 	)
 
 	require.NotNil(a)
 	for _, k := range []string{"a", "alsdkjfa;lksehjuro8iwurjhf", "asdf8974", "875kjh4", "928375hjdfgkyu9832745kjshdfgoi873465"} {
 		i, err := a.Get([]byte(k))
-		assert.Equal("an instance", i)
+		assert.Equal("https://example.com", i)
 		assert.NoError(err)
 	}
 }
@@ -55,13 +55,67 @@ func testNewConsistentAccessorFactory(t *testing.T, vnodeCount int) {
 	)
 
 	require.NotNil(af)
-	a := af([]string{"an instance"})
+	a := af([]string{"https://example.com"})
 	require.NotNil(a)
 	for _, k := range []string{"a", "alsdkjfa;lksehjuro8iwurjhf", "asdf8974", "875kjh4", "928375hjdfgkyu9832745kjshdfgoi873465"} {
 		i, err := a.Get([]byte(k))
-		assert.Equal("an instance", i)
+		assert.Equal("https://example.com", i)
 		assert.NoError(err)
 	}
+}
+
+func TestHostHasherPanics(t *testing.T) {
+	var (
+		require = require.New(t)
+		hh      = newHostHasher(DefaultVnodeCount)
+	)
+
+	require.NotNil(hh)
+	tests := []struct {
+		description string
+		url         string
+	}{
+		{
+			"formating error",
+			"[2001:0db8:85a3:0000:0000:8a2e:0370:7334]",
+		},
+		{
+			"missing host error",
+			"https://",
+		},
+		{
+			"missing schema error",
+			"example.com",
+		},
+	}
+
+	for _, tc := range tests {
+		require.Panics(func() {
+			hh.Add(tc.url)
+		})
+	}
+}
+
+func TestHostHasher(t *testing.T) {
+	var (
+		require = require.New(t)
+		hh      = newHostHasher(DefaultVnodeCount)
+	)
+
+	require.NotNil(hh)
+	hostToURLTests := map[string]string{
+		"1.2.3.4": "https://1.2.3.4",
+		"2001:0db8:85a3:0000:0000:8a2e:0370:7334": "https://2001:0db8:85a3:0000:0000:8a2e:0370:7334:17000",
+		"foo.com":                            "https://foo.com:80",
+		"some.super.long.domain.example.com": "https://some.super.long.domain.example.com:8080/somepath",
+	}
+	// Add urls
+	for _, url := range hostToURLTests {
+		hh.Add(url)
+	}
+
+	// Check the maps are the same.
+	require.Equal(hostToURLTests, hh.hostToURL)
 }
 
 func TestNewConsistentAccessorFactory(t *testing.T) {
@@ -81,11 +135,11 @@ func testNewConsistentAccessorFactoryWithGate(t *testing.T, vnodeCount int, g ga
 	)
 
 	require.NotNil(af)
-	a := af([]string{"an instance"})
+	a := af([]string{"https://example.com"})
 	require.NotNil(a)
 	for _, k := range []string{"a", "alsdkjfa;lksehjuro8iwurjhf", "asdf8974", "875kjh4", "928375hjdfgkyu9832745kjshdfgoi873465"} {
 		i, err := a.Get([]byte(k))
-		assert.Equal("an instance", i)
+		assert.Equal("https://example.com", i)
 		if (g != nil && g.Open()) || g == nil {
 			assert.NoError(err)
 		} else if g != nil && !g.Open() {
@@ -115,13 +169,13 @@ func TestDefaultAccessorFactory(t *testing.T) {
 		assert  = assert.New(t)
 		require = require.New(t)
 
-		a = DefaultAccessorFactory([]string{"an instance"})
+		a = DefaultAccessorFactory([]string{"https://example.com"})
 	)
 
 	require.NotNil(a)
 	for _, k := range []string{"a", "alsdkjfa;lksehjuro8iwurjhf", "asdf8974", "875kjh4", "928375hjdfgkyu9832745kjshdfgoi873465"} {
 		i, err := a.Get([]byte(k))
-		assert.Equal("an instance", i)
+		assert.Equal("https://example.com", i)
 		assert.NoError(err)
 	}
 }


### PR DESCRIPTION
- previously we used the full registered consul url for hashing, leading to issues when the urls resulted in different hash rings across services
- our hashing should only consider the host component of the url