### PR TITLE
refactor: move accessor related code into its own package

### DIFF
--- a/device/rehasher/rehasher.go
+++ b/device/rehasher/rehasher.go
@@ -10,6 +10,7 @@ import (
 	"github.com/xmidt-org/sallust"
 	"github.com/xmidt-org/webpa-common/v2/device"
 	"github.com/xmidt-org/webpa-common/v2/service"
+	"github.com/xmidt-org/webpa-common/v2/service/accessor"
 	"github.com/xmidt-org/webpa-common/v2/service/monitor"
 )
 
@@ -36,12 +37,12 @@ func WithLogger(l *zap.Logger) Option {
 	}
 }
 
-// WithAccessorFactory configures a rehasher with a specific factory for service.Accessor objects.
+// WithAccessorFactory configures a rehasher with a specific factory for accessor.Accessor objects.
 // If af is nil, the default accessor factory is used.
-func WithAccessorFactory(af service.AccessorFactory) Option {
+func WithAccessorFactory(af accessor.AccessorFactory) Option {
 	return func(r *rehasher) {
 		if af == nil {
-			r.accessorFactory = service.DefaultAccessorFactory
+			r.accessorFactory = accessor.DefaultAccessorFactory
 		} else {
 			r.accessorFactory = af
 		}
@@ -94,7 +95,7 @@ func New(connector device.Connector, services []string, options ...Option) monit
 
 		r = &rehasher{
 			logger:          sallust.Default(),
-			accessorFactory: service.DefaultAccessorFactory,
+			accessorFactory: accessor.DefaultAccessorFactory,
 			connector:       connector,
 			now:             time.Now,
 			services:        make(map[string]bool),
@@ -127,7 +128,7 @@ func New(connector device.Connector, services []string, options ...Option) monit
 type rehasher struct {
 	logger          *zap.Logger
 	services        map[string]bool
-	accessorFactory service.AccessorFactory
+	accessorFactory accessor.AccessorFactory
 	isRegistered    func(string) bool
 	connector       device.Connector
 	now             func() time.Time
@@ -139,7 +140,7 @@ type rehasher struct {
 	duration             metrics.Gauge
 }
 
-func (r *rehasher) rehash(svc string, logger *zap.Logger, accessor service.Accessor) {
+func (r *rehasher) rehash(svc string, logger *zap.Logger, accessor accessor.Accessor) {
 	logger.Info("rehash starting")
 
 	start := r.now()

--- a/device/rehasher/rehasher_test.go
+++ b/device/rehasher/rehasher_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/xmidt-org/sallust"
 	"github.com/xmidt-org/webpa-common/v2/device"
 	"github.com/xmidt-org/webpa-common/v2/service"
+	"github.com/xmidt-org/webpa-common/v2/service/accessor"
 	"github.com/xmidt-org/webpa-common/v2/service/monitor"
 	"github.com/xmidt-org/webpa-common/v2/xmetrics/xmetricstest"
 )
@@ -299,9 +300,9 @@ func testRehasherRehash(t *testing.T) {
 		accessorError   = errors.New("expected accessor error")
 
 		expectedNodes   = []string{keepNode, rehashNode}
-		accessorFactory = service.AccessorFactory(func(actualNodes []string) service.Accessor {
+		accessorFactory = accessor.AccessorFactory(func(actualNodes []string) accessor.Accessor {
 			assert.Equal(expectedNodes, actualNodes)
-			return service.AccessorFunc(func(key []byte) (string, error) {
+			return accessor.AccessorFunc(func(key []byte) (string, error) {
 				switch string(key) {
 				case string(keepID):
 					return keepNode, nil

--- a/service/accessor/accessor.go
+++ b/service/accessor/accessor.go
@@ -1,4 +1,4 @@
-package service
+package accessor
 
 import (
 	"errors"

--- a/service/accessor/accessorFactory.go
+++ b/service/accessor/accessorFactory.go
@@ -1,4 +1,4 @@
-package service
+package accessor
 
 import (
 	"fmt"

--- a/service/accessor/accessorFactory_test.go
+++ b/service/accessor/accessorFactory_test.go
@@ -1,4 +1,4 @@
-package service
+package accessor
 
 import (
 	"fmt"

--- a/service/accessor/accessor_benchmarks_test.go
+++ b/service/accessor/accessor_benchmarks_test.go
@@ -1,4 +1,4 @@
-package service
+package accessor
 
 import (
 	"encoding/base64"

--- a/service/accessor/accessor_test.go
+++ b/service/accessor/accessor_test.go
@@ -1,10 +1,11 @@
-package service
+package accessor
 
 import (
 	"errors"
-	"github.com/stretchr/testify/mock"
 	"sort"
 	"testing"
+
+	"github.com/stretchr/testify/mock"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/service/accessor/gateaccessor.go
+++ b/service/accessor/gateaccessor.go
@@ -1,4 +1,4 @@
-package service
+package accessor
 
 import (
 	"errors"
@@ -13,16 +13,16 @@ type gateAccessor struct {
 	Accessor Accessor
 }
 
-func GateAccessor(g gate.Interface, accessor Accessor) Accessor {
+func GateAccessor(g gate.Interface, a Accessor) Accessor {
 	if g == nil {
 		g = gate.New(true)
 	}
-	if accessor == nil {
-		accessor = EmptyAccessor()
+	if a == nil {
+		a = EmptyAccessor()
 	}
 	return gateAccessor{
 		Gate:     g,
-		Accessor: accessor,
+		Accessor: a,
 	}
 }
 

--- a/service/accessor/gateaccessor_test.go
+++ b/service/accessor/gateaccessor_test.go
@@ -1,11 +1,12 @@
-package service
+package accessor
 
 import (
 	"errors"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 /****************** BEGIN MOCK DECLARATIONS ***********************/

--- a/service/accessor/main_test.go
+++ b/service/accessor/main_test.go
@@ -1,4 +1,4 @@
-package service
+package accessor
 
 import (
 	"flag"

--- a/service/accessor/mock.go
+++ b/service/accessor/mock.go
@@ -1,0 +1,15 @@
+package accessor
+
+import "github.com/stretchr/testify/mock"
+
+// MockAccessor is a mocked Accessor
+type MockAccessor struct {
+	mock.Mock
+}
+
+var _ Accessor = (*MockAccessor)(nil)
+
+func (m *MockAccessor) Get(v []byte) (string, error) {
+	arguments := m.Called(v)
+	return arguments.String(0), arguments.Error(1)
+}

--- a/service/endpoint.go
+++ b/service/endpoint.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/go-kit/kit/endpoint"
+	"github.com/xmidt-org/webpa-common/v2/service/accessor"
 )
 
 // Key represents a service key.
@@ -26,7 +27,7 @@ type KeyParser func(string) (Key, error)
 // NewAccessorEndpoint produces a go-kit Endpoint which delegates to an Accessor.
 // The returned Endpoint expects a service Key as its request, and returns the instance
 // string as the response.
-func NewAccessorEndpoint(a Accessor) endpoint.Endpoint {
+func NewAccessorEndpoint(a accessor.Accessor) endpoint.Endpoint {
 	if a == nil {
 		panic("an Accessor is required")
 	}

--- a/service/endpoint_test.go
+++ b/service/endpoint_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/xmidt-org/webpa-common/v2/service/accessor"
 )
 
 func testNewAccessorEndpointNilAccessor(t *testing.T) {
@@ -23,7 +24,7 @@ func testNewAccessorEndpointSuccess(t *testing.T) {
 
 		expectedKey = StringKey("expected key")
 
-		a = new(MockAccessor)
+		a = new(accessor.MockAccessor)
 		e = NewAccessorEndpoint(a)
 	)
 
@@ -45,7 +46,7 @@ func testNewAccessorEndpointError(t *testing.T) {
 		expectedKey   = StringKey("expected key")
 		expectedError = errors.New("expected error")
 
-		a = new(MockAccessor)
+		a = new(accessor.MockAccessor)
 		e = NewAccessorEndpoint(a)
 	)
 

--- a/service/environment.go
+++ b/service/environment.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/go-kit/kit/sd"
+	"github.com/xmidt-org/webpa-common/v2/service/accessor"
 	"github.com/xmidt-org/webpa-common/v2/xmetrics"
 )
 
@@ -43,7 +44,7 @@ type Environment interface {
 
 	// AccessorFactory returns the creation strategy for Accessors used in this environment.
 	// Typically, this factory is set via configuration by some external source.
-	AccessorFactory() AccessorFactory
+	AccessorFactory() accessor.AccessorFactory
 
 	// Closed returns a channel that is closed when this Environment in closed.
 	Closed() <-chan struct{}
@@ -89,10 +90,10 @@ func WithInstancers(i Instancers) Option {
 // WithAccessorFactory configures the creation strategy for Accessor objects.  By default,
 // DefaultAccessorFactory is used.  Passing nil via this option sets (or resets) the environment
 // back to using the DefaultAccessorFactory.
-func WithAccessorFactory(af AccessorFactory) Option {
+func WithAccessorFactory(af accessor.AccessorFactory) Option {
 	return func(e *environment) {
 		if af == nil {
-			e.accessorFactory = DefaultAccessorFactory
+			e.accessorFactory = accessor.DefaultAccessorFactory
 		} else {
 			e.accessorFactory = af
 		}
@@ -126,7 +127,7 @@ func WithProvider(p xmetrics.Registry) Option {
 func NewEnvironment(options ...Option) Environment {
 	e := &environment{
 		defaultScheme:   DefaultScheme,
-		accessorFactory: DefaultAccessorFactory,
+		accessorFactory: accessor.DefaultAccessorFactory,
 		closer:          NopCloser,
 		closed:          make(chan struct{}),
 	}
@@ -142,7 +143,7 @@ type environment struct {
 	defaultScheme   string
 	registrars      Registrars
 	instancers      Instancers
-	accessorFactory AccessorFactory
+	accessorFactory accessor.AccessorFactory
 	provider        xmetrics.Registry
 
 	lock      sync.RWMutex
@@ -190,7 +191,7 @@ func (e *environment) UpdateInstancers(currentKeys map[string]bool, instancersTo
 	e.lock.Unlock()
 }
 
-func (e *environment) AccessorFactory() AccessorFactory {
+func (e *environment) AccessorFactory() accessor.AccessorFactory {
 	return e.accessorFactory
 }
 

--- a/service/environment_test.go
+++ b/service/environment_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/xmidt-org/webpa-common/v2/service/accessor"
 )
 
 func TestNopCloser(t *testing.T) {
@@ -68,9 +69,9 @@ func testNewEnvironmentWithOptions(t *testing.T) {
 		instancers = Instancers{"test": instancer}
 
 		accessorFactoryCalled = false
-		accessorFactory       = func(i []string) Accessor {
+		accessorFactory       = func(i []string) accessor.Accessor {
 			accessorFactoryCalled = true
-			return EmptyAccessor()
+			return accessor.EmptyAccessor()
 		}
 
 		expectedCloseError = errors.New("expected")

--- a/service/mocks.go
+++ b/service/mocks.go
@@ -3,20 +3,9 @@ package service
 import (
 	"github.com/go-kit/kit/sd"
 	"github.com/stretchr/testify/mock"
+	"github.com/xmidt-org/webpa-common/v2/service/accessor"
 	"github.com/xmidt-org/webpa-common/v2/xmetrics"
 )
-
-// MockAccessor is a mocked Accessor
-type MockAccessor struct {
-	mock.Mock
-}
-
-var _ Accessor = (*MockAccessor)(nil)
-
-func (m *MockAccessor) Get(v []byte) (string, error) {
-	arguments := m.Called(v)
-	return arguments.String(0), arguments.Error(1)
-}
 
 // MockRegistrar is a stretchr/testify mocked sd.Registrar
 type MockRegistrar struct {
@@ -87,8 +76,8 @@ func (m *MockEnvironment) UpdateInstancers(currentKeys map[string]bool, instance
 	m.Called(currentKeys, instancersToAdd)
 }
 
-func (m *MockEnvironment) AccessorFactory() AccessorFactory {
-	return m.Called().Get(0).(AccessorFactory)
+func (m *MockEnvironment) AccessorFactory() accessor.AccessorFactory {
+	return m.Called().Get(0).(accessor.AccessorFactory)
 }
 
 func (m *MockEnvironment) Closed() <-chan struct{} {

--- a/service/mocks_test.go
+++ b/service/mocks_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-kit/kit/sd"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/xmidt-org/webpa-common/v2/service/accessor"
 )
 
 func TestMockRegistrar(t *testing.T) {
@@ -50,9 +51,9 @@ func TestMockEnvironment(t *testing.T) {
 		closeError = errors.New("expected close error")
 
 		accessorFactoryCalled = false
-		accessorFactory       = AccessorFactory(func(i []string) Accessor {
+		accessorFactory       = accessor.AccessorFactory(func(i []string) accessor.Accessor {
 			accessorFactoryCalled = true
-			return EmptyAccessor()
+			return accessor.EmptyAccessor()
 		})
 	)
 
@@ -76,7 +77,7 @@ func TestMockEnvironment(t *testing.T) {
 
 	af := e.AccessorFactory()
 	require.NotNil(af)
-	assert.Equal(EmptyAccessor(), af([]string{}))
+	assert.Equal(accessor.EmptyAccessor(), af([]string{}))
 	assert.True(accessorFactoryCalled)
 
 	assert.Equal((<-chan struct{})(closed), e.Closed())

--- a/service/monitor/listener.go
+++ b/service/monitor/listener.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-kit/kit/sd"
 	"github.com/xmidt-org/sallust"
 	"github.com/xmidt-org/webpa-common/v2/service"
+	"github.com/xmidt-org/webpa-common/v2/service/accessor"
 	"go.uber.org/zap"
 )
 
@@ -93,13 +94,13 @@ func NewMetricsListener(p provider.Provider) Listener {
 //
 //	ua := new(UpdatableAccessor)
 //	l := NewAccessorListener(f, ua.Update)
-func NewAccessorListener(f service.AccessorFactory, next func(service.Accessor, error)) Listener {
+func NewAccessorListener(f accessor.AccessorFactory, next func(accessor.Accessor, error)) Listener {
 	if next == nil {
 		panic("A next closure is required to receive Accessors")
 	}
 
 	if f == nil {
-		f = service.DefaultAccessorFactory
+		f = accessor.DefaultAccessorFactory
 	}
 
 	return ListenerFunc(func(e Event) {
@@ -111,18 +112,18 @@ func NewAccessorListener(f service.AccessorFactory, next func(service.Accessor, 
 			next(f(e.Instances), nil)
 
 		default:
-			next(service.EmptyAccessor(), nil)
+			next(accessor.EmptyAccessor(), nil)
 		}
 	})
 }
 
-func NewKeyAccessorListener(f service.AccessorFactory, key string, next func(string, service.Accessor, error)) Listener {
+func NewKeyAccessorListener(f accessor.AccessorFactory, key string, next func(string, accessor.Accessor, error)) Listener {
 	if next == nil {
 		panic("A next closure is required to receive Accessors")
 	}
 
 	if f == nil {
-		f = service.DefaultAccessorFactory
+		f = accessor.DefaultAccessorFactory
 	}
 
 	return ListenerFunc(func(e Event) {
@@ -134,7 +135,7 @@ func NewKeyAccessorListener(f service.AccessorFactory, key string, next func(str
 			next(key, f(e.Instances), nil)
 
 		default:
-			next(key, service.EmptyAccessor(), nil)
+			next(key, accessor.EmptyAccessor(), nil)
 		}
 	})
 }

--- a/service/monitor/listener_test.go
+++ b/service/monitor/listener_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/xmidt-org/sallust"
 	"github.com/xmidt-org/webpa-common/v2/service"
+	"github.com/xmidt-org/webpa-common/v2/service/accessor"
 	"github.com/xmidt-org/webpa-common/v2/xmetrics/xmetricstest"
 	"go.uber.org/zap"
 )
@@ -113,11 +114,11 @@ func TestNewMetricsListener(t *testing.T) {
 func testNewAccessorListenerMissingNext(t *testing.T) {
 	assert := assert.New(t)
 	assert.Panics(func() {
-		NewAccessorListener(service.DefaultAccessorFactory, nil)
+		NewAccessorListener(accessor.DefaultAccessorFactory, nil)
 	})
 }
 
-func testNewAccessorListenerError(t *testing.T, f service.AccessorFactory) {
+func testNewAccessorListenerError(t *testing.T, f accessor.AccessorFactory) {
 	var (
 		assert        = assert.New(t)
 		require       = require.New(t)
@@ -126,7 +127,7 @@ func testNewAccessorListenerError(t *testing.T, f service.AccessorFactory) {
 
 		l = NewAccessorListener(
 			f,
-			func(a service.Accessor, err error) {
+			func(a accessor.Accessor, err error) {
 				nextCalled = true
 				assert.Nil(a)
 				assert.Equal(expectedError, err)
@@ -148,7 +149,7 @@ func testNewAccessorListenerInstances(t *testing.T) {
 
 		l = NewAccessorListener(
 			nil,
-			func(a service.Accessor, err error) {
+			func(a accessor.Accessor, err error) {
 				nextCalled = true
 				require.NotNil(a)
 				assert.NoError(err)
@@ -173,9 +174,9 @@ func testNewAccessorListenerEmpty(t *testing.T) {
 
 		l = NewAccessorListener(
 			nil,
-			func(a service.Accessor, err error) {
+			func(a accessor.Accessor, err error) {
 				nextCalled = true
-				assert.Equal(service.EmptyAccessor(), a)
+				assert.Equal(accessor.EmptyAccessor(), a)
 				assert.NoError(err)
 			},
 		)
@@ -191,7 +192,7 @@ func TestNewAccessorListener(t *testing.T) {
 
 	t.Run("DefaultAccessorFactory", func(t *testing.T) {
 		t.Run("Error", func(t *testing.T) {
-			testNewAccessorListenerError(t, service.DefaultAccessorFactory)
+			testNewAccessorListenerError(t, accessor.DefaultAccessorFactory)
 		})
 
 		t.Run("Instances", func(t *testing.T) {
@@ -204,7 +205,7 @@ func TestNewAccessorListener(t *testing.T) {
 	})
 
 	t.Run("CustomAccessorFactory", func(t *testing.T) {
-		f := service.NewConsistentAccessorFactory(2)
+		f := accessor.NewConsistentAccessorFactory(2)
 
 		t.Run("Error", func(t *testing.T) {
 			testNewAccessorListenerError(t, f)

--- a/service/servicecfg/environment.go
+++ b/service/servicecfg/environment.go
@@ -6,6 +6,7 @@ import (
 	"github.com/go-kit/kit/sd"
 	"github.com/xmidt-org/webpa-common/v2/adapter"
 	"github.com/xmidt-org/webpa-common/v2/service"
+	"github.com/xmidt-org/webpa-common/v2/service/accessor"
 	"github.com/xmidt-org/webpa-common/v2/service/consul"
 	"github.com/xmidt-org/webpa-common/v2/service/zk"
 	"github.com/xmidt-org/webpa-common/v2/xviper"
@@ -30,7 +31,7 @@ func NewEnvironment(l *adapter.Logger, u xviper.Unmarshaler, options ...service.
 	}
 	eo := []service.Option{
 		service.WithAccessorFactory(
-			service.NewConsistentAccessorFactory(o.vnodeCount()),
+			accessor.NewConsistentAccessorFactory(o.vnodeCount()),
 		),
 		service.WithDefaultScheme(o.defaultScheme()),
 	}

--- a/service/servicecfg/options.go
+++ b/service/servicecfg/options.go
@@ -2,6 +2,7 @@ package servicecfg
 
 import (
 	"github.com/xmidt-org/webpa-common/v2/service"
+	"github.com/xmidt-org/webpa-common/v2/service/accessor"
 	"github.com/xmidt-org/webpa-common/v2/service/consul"
 	"github.com/xmidt-org/webpa-common/v2/service/zk"
 )
@@ -22,7 +23,7 @@ func (o *Options) vnodeCount() int {
 		return o.VnodeCount
 	}
 
-	return service.DefaultVnodeCount
+	return accessor.DefaultVnodeCount
 }
 
 func (o *Options) disableFilter() bool {

--- a/service/servicecfg/options_test.go
+++ b/service/servicecfg/options_test.go
@@ -5,11 +5,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/xmidt-org/webpa-common/v2/service"
+	"github.com/xmidt-org/webpa-common/v2/service/accessor"
 )
 
 func testOptionsDefault(t *testing.T, o *Options) {
 	assert := assert.New(t)
-	assert.Equal(service.DefaultVnodeCount, o.vnodeCount())
+	assert.Equal(accessor.DefaultVnodeCount, o.vnodeCount())
 	assert.False(o.disableFilter())
 	assert.Equal(service.DefaultScheme, o.defaultScheme())
 }

--- a/service/servicehttp/hashFilter.go
+++ b/service/servicehttp/hashFilter.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/xmidt-org/sallust/sallusthttp"
 	"github.com/xmidt-org/webpa-common/v2/device"
-	"github.com/xmidt-org/webpa-common/v2/service"
+	"github.com/xmidt-org/webpa-common/v2/service/accessor"
 	"github.com/xmidt-org/webpa-common/v2/xhttp/xfilter"
 	"go.uber.org/zap"
 )
@@ -15,7 +15,7 @@ import (
 //
 // The returned filter will check the request's context for a device id, using that to hash with if one is found.
 // Otherwise, the device key is parsed from the request via device.IDHashParser.
-func NewHashFilter(a service.Accessor, reject error, self func(string) bool) xfilter.Interface {
+func NewHashFilter(a accessor.Accessor, reject error, self func(string) bool) xfilter.Interface {
 	// allow any nil parameter to simply disable the filtering
 	if a == nil || reject == nil || self == nil {
 		return xfilter.Allow()

--- a/service/servicehttp/hashFilter_test.go
+++ b/service/servicehttp/hashFilter_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/xmidt-org/sallust"
 	"github.com/xmidt-org/webpa-common/v2/device"
-	"github.com/xmidt-org/webpa-common/v2/service"
+	"github.com/xmidt-org/webpa-common/v2/service/accessor"
 )
 
 func testNewHashFilterNoAccessor(t *testing.T) {
@@ -36,7 +36,7 @@ func testNewHashFilterNoReject(t *testing.T) {
 		assert  = assert.New(t)
 		require = require.New(t)
 
-		a = new(service.MockAccessor)
+		a = new(accessor.MockAccessor)
 
 		self = func(string) bool {
 			assert.Fail("The self predicate should not have been called")
@@ -56,7 +56,7 @@ func testNewHashFilterNoSelf(t *testing.T) {
 		assert  = assert.New(t)
 		require = require.New(t)
 
-		a  = new(service.MockAccessor)
+		a  = new(accessor.MockAccessor)
 		hf = NewHashFilter(a, errors.New("reject"), nil)
 	)
 
@@ -76,7 +76,7 @@ func testNewHashFilterParseError(t *testing.T) {
 			return false
 		}
 
-		accessor = new(service.MockAccessor)
+		accessor = new(accessor.MockAccessor)
 		hf       = NewHashFilter(accessor, errors.New("reject"), self)
 	)
 
@@ -101,7 +101,7 @@ func testNewHashFilterHashError(t *testing.T) {
 		}
 
 		hashErr  = errors.New("hash")
-		accessor = new(service.MockAccessor)
+		accessor = new(accessor.MockAccessor)
 		hf       = NewHashFilter(accessor, errors.New("reject"), self)
 	)
 
@@ -138,7 +138,7 @@ func testNewHashFilterAllow(t *testing.T) {
 			return true
 		}
 
-		a  = new(service.MockAccessor)
+		a  = new(accessor.MockAccessor)
 		hf = NewHashFilter(a, errors.New("reject"), self)
 	)
 
@@ -169,7 +169,7 @@ func testNewHashFilterReject(t *testing.T) {
 			return false
 		}
 
-		a           = new(service.MockAccessor)
+		a           = new(accessor.MockAccessor)
 		expectedErr = errors.New("expected")
 		hf          = NewHashFilter(a, expectedErr, self)
 	)

--- a/service/servicehttp/redirectHandler.go
+++ b/service/servicehttp/redirectHandler.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/xmidt-org/sallust/sallusthttp"
-	"github.com/xmidt-org/webpa-common/v2/service"
+	"github.com/xmidt-org/webpa-common/v2/service/accessor"
 	"go.uber.org/zap"
 )
 
@@ -22,7 +22,7 @@ type RedirectHandler struct {
 	KeyFunc KeyFunc
 
 	// Accessor produces instances given hash keys.  Note that a Subscription implements the Accessor interface.
-	Accessor service.Accessor
+	Accessor accessor.Accessor
 
 	// RedirectCode is the HTTP status code sent as part of the redirect.  If not set, http.StatusTemporaryRedirect is used.
 	RedirectCode int

--- a/service/servicehttp/redirectHandler_test.go
+++ b/service/servicehttp/redirectHandler_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/xmidt-org/webpa-common/v2/service"
+	"github.com/xmidt-org/webpa-common/v2/service/accessor"
 )
 
 func testRedirectHandlerKeyFuncError(t *testing.T) {
@@ -16,7 +16,7 @@ func testRedirectHandlerKeyFuncError(t *testing.T) {
 
 		expectedError = errors.New("expected")
 		keyFunc       = func(*http.Request) ([]byte, error) { return nil, expectedError }
-		accessor      = new(service.MockAccessor)
+		accessor      = new(accessor.MockAccessor)
 
 		response = httptest.NewRecorder()
 		request  = httptest.NewRequest("GET", "/", nil)
@@ -41,7 +41,7 @@ func testRedirectHandlerAccessorError(t *testing.T) {
 		expectedKey   = []byte("34589lkdjasd")
 		keyFunc       = func(*http.Request) ([]byte, error) { return expectedKey, nil }
 		expectedError = errors.New("expected")
-		accessor      = new(service.MockAccessor)
+		accessor      = new(accessor.MockAccessor)
 
 		response = httptest.NewRecorder()
 		request  = httptest.NewRequest("GET", "/", nil)
@@ -67,7 +67,7 @@ func testRedirectHandlerSuccess(t *testing.T) {
 		expectedKey      = []byte("asdfqwer")
 		expectedInstance = "https://ahost123.com:324"
 		keyFunc          = func(*http.Request) ([]byte, error) { return expectedKey, nil }
-		accessor         = new(service.MockAccessor)
+		accessor         = new(accessor.MockAccessor)
 
 		response = httptest.NewRecorder()
 		request  = httptest.NewRequest("GET", "/", nil)
@@ -96,7 +96,7 @@ func testRedirectHandlerSuccessWithPath(t *testing.T) {
 		requestURI          = "/this/awesome/path"
 		expectedRedirectURL = expectedInstance + requestURI
 		keyFunc             = func(*http.Request) ([]byte, error) { return expectedKey, nil }
-		accessor            = new(service.MockAccessor)
+		accessor            = new(accessor.MockAccessor)
 
 		response = httptest.NewRecorder()
 		request  = httptest.NewRequest("GET", "https://someIrrelevantHost.com"+requestURI, nil)

--- a/xhttp/fanout/serviceEndpoints.go
+++ b/xhttp/fanout/serviceEndpoints.go
@@ -7,8 +7,9 @@ import (
 
 	"github.com/xmidt-org/webpa-common/v2/device"
 	// nolint:staticcheck
-	"github.com/xmidt-org/webpa-common/v2/service"
+
 	// nolint:staticcheck
+	"github.com/xmidt-org/webpa-common/v2/service/accessor"
 	"github.com/xmidt-org/webpa-common/v2/service/monitor"
 	// nolint:staticcheck
 	"github.com/xmidt-org/webpa-common/v2/service/servicehttp"
@@ -21,8 +22,8 @@ import (
 type ServiceEndpoints struct {
 	lock            sync.RWMutex
 	keyFunc         servicehttp.KeyFunc
-	accessorFactory service.AccessorFactory
-	accessors       map[string]service.Accessor
+	accessorFactory accessor.AccessorFactory
+	accessors       map[string]accessor.Accessor
 }
 
 // FanoutURLs uses the currently available discovered endpoints to produce a set of URLs.
@@ -77,24 +78,24 @@ func WithKeyFunc(kf servicehttp.KeyFunc) ServiceEndpointsOption {
 }
 
 // WithAccessorFactory configures an accessor factory for the given service endpoints.
-// If nil, then service.DefaultAccessorFactory is used.
-func WithAccessorFactory(af service.AccessorFactory) ServiceEndpointsOption {
+// If nil, then accessor.DefaultAccessorFactory is used.
+func WithAccessorFactory(af accessor.AccessorFactory) ServiceEndpointsOption {
 	return func(se *ServiceEndpoints) {
 		if af != nil {
 			se.accessorFactory = af
 		} else {
-			se.accessorFactory = service.DefaultAccessorFactory
+			se.accessorFactory = accessor.DefaultAccessorFactory
 		}
 	}
 }
 
 // NewServiceEndpoints creates a ServiceEndpoints instance.  By default, device.IDHashParser is used as the KeyFunc
-// and service.DefaultAccessorFactory is used as the accessor factory.
+// and accessor.DefaultAccessorFactory is used as the accessor factory.
 func NewServiceEndpoints(options ...ServiceEndpointsOption) *ServiceEndpoints {
 	se := &ServiceEndpoints{
 		keyFunc:         device.IDHashParser,
-		accessorFactory: service.DefaultAccessorFactory,
-		accessors:       make(map[string]service.Accessor),
+		accessorFactory: accessor.DefaultAccessorFactory,
+		accessors:       make(map[string]accessor.Accessor),
 	}
 
 	for _, o := range options {

--- a/xhttp/fanout/serviceEndpoints_test.go
+++ b/xhttp/fanout/serviceEndpoints_test.go
@@ -16,6 +16,7 @@ import (
 	// nolint:staticcheck
 	"github.com/xmidt-org/webpa-common/v2/service"
 	// nolint:staticcheck
+	"github.com/xmidt-org/webpa-common/v2/service/accessor"
 	"github.com/xmidt-org/webpa-common/v2/service/monitor"
 )
 
@@ -110,9 +111,9 @@ func testNewServiceEndpointsCustom(t *testing.T) {
 		}
 
 		accessorFactoryCalled = false
-		accessorFactory       = func(instances []string) service.Accessor {
+		accessorFactory       = func(instances []string) accessor.Accessor {
 			accessorFactoryCalled = true
-			return service.DefaultAccessorFactory(instances)
+			return accessor.DefaultAccessorFactory(instances)
 		}
 
 		se = NewServiceEndpoints(WithAccessorFactory(accessorFactory), WithKeyFunc(keyFunc))


### PR DESCRIPTION
This is prep work for the `configurable accessor` feature. The new package affords us room to implement the new feature cleanly