### PR TITLE
feat: when available source device id from themis' JWT claims instead from the request headers

### DIFF
--- a/device/manager.go
+++ b/device/manager.go
@@ -5,6 +5,7 @@ package device
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -190,20 +191,36 @@ type manager struct {
 func (m *manager) Connect(response http.ResponseWriter, request *http.Request, responseHeader http.Header) (Interface, error) {
 	m.logger.Debug("device connect", zap.Any("url", request.URL))
 	ctx := request.Context()
-	id, ok := GetID(ctx)
-	if !ok {
-		xhttp.WriteError(
-			response,
-			http.StatusInternalServerError,
-			ErrorMissingDeviceNameContext,
-		)
-
-		return nil, ErrorMissingDeviceNameContext
-	}
-
 	metadata, ok := GetDeviceMetadata(ctx)
 	if !ok {
 		metadata = new(Metadata)
+	}
+
+	// Always use the device-id provided by themis if available.
+	// Otherwise, fallback to using the device-id from the X-Webpa-Device-Name request header.
+	id, err := metadata.DeviceIDClaim()
+	if err != nil {
+		err = errors.Join(ErrorInvalidDeviceName, err)
+		xhttp.WriteError(
+			response,
+			http.StatusInternalServerError,
+			err,
+		)
+
+		return nil, err
+	}
+
+	if len(id) == 0 {
+		id, ok = GetID(ctx)
+		if !ok {
+			xhttp.WriteError(
+				response,
+				http.StatusInternalServerError,
+				ErrorMissingDeviceNameContext,
+			)
+
+			return nil, ErrorMissingDeviceNameContext
+		}
 	}
 
 	cvy, cvyErr := m.conveyTranslator.FromHeader(request.Header)

--- a/device/manager_test.go
+++ b/device/manager_test.go
@@ -4,6 +4,7 @@
 package device
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -45,6 +46,32 @@ func startWebsocketServer(o *Options) (Manager, *httptest.Server, string) {
 					Logger:    o.logger(),
 					Connector: manager,
 				},
+			),
+		)
+
+		websocketURL, err = url.Parse(server.URL)
+	)
+
+	if err != nil {
+		server.Close()
+		panic(fmt.Errorf("Unable to parse test server URL: %s", err))
+	}
+
+	websocketURL.Scheme = "ws"
+	return manager, server, websocketURL.String()
+}
+
+func startWebsocketServerWithRequestContext(o *Options, ctx context.Context) (Manager, *httptest.Server, string) {
+	var (
+		manager = NewManager(o)
+		server  = httptest.NewServer(
+			alice.New(UseID.FromHeader).Then(
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					(&ConnectHandler{
+						Logger:    o.logger(),
+						Connector: manager,
+					}).ServeHTTP(w, r.WithContext(ctx))
+				}),
 			),
 		)
 
@@ -142,6 +169,129 @@ func testManagerConnectUpgradeError(t *testing.T) {
 	device, actualError := manager.Connect(response, request, responseHeader)
 	assert.Nil(device)
 	assert.Error(actualError)
+}
+
+func testManagerConnectDeviceIDFromClaimsError(t *testing.T) {
+	assert := assert.New(t)
+	metadata := new(Metadata)
+	metadata.SetClaims(map[string]any{
+		AccountIDClaimKey: "abc123",
+	})
+	manager := NewManager(&Options{
+		Logger: zap.NewNop(),
+		Listeners: []Listener{
+			func(e *Event) {
+				assert.Fail("The listener should not have been called")
+			},
+		},
+	})
+	metadata.SetClaims(map[string]any{DeviceIDClaimKey: "mac:invalid"})
+	request := httptest.NewRequestWithContext(WithDeviceMetadata(context.Background(), metadata), "POST", "http://localhost.com", nil)
+	device, err := manager.Connect(httptest.NewRecorder(), request, http.Header{})
+	assert.Empty(device)
+	assert.ErrorIs(err, ErrorInvalidDeviceName)
+}
+
+func testManagerConnectDeviceIDFromClaims(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	metadata := new(Metadata)
+	realID := ID("mac:123412341234")
+	metadata.SetClaims(map[string]any{
+		AccountIDClaimKey: "abc123",
+		DeviceIDClaimKey:  string(realID),
+	})
+	spoofedID := ID("mac:1800DEADBEEF")
+	connections := make(chan *device, 1)
+	connectWait := new(sync.WaitGroup)
+	_, server, connectURL := startWebsocketServerWithRequestContext(
+		&Options{
+			Logger: zap.NewNop(),
+			Listeners: []Listener{
+				func(event *Event) {
+					if event.Type == Connect {
+						assert.NoError(event.Error)
+						d := event.Device.(*device)
+						defer connectWait.Done()
+						select {
+						case connections <- d:
+						default:
+							assert.Fail("The connect listener should not block")
+						}
+					}
+				},
+			},
+		},
+		// Device ID supplied via a JWT claims set, Xmidt should use this instead of a Device ID from a header.
+		WithDeviceMetadata(context.Background(), metadata))
+
+	defer server.Close()
+
+	// A spoofed ID will be supplied via a header but it should not be used since a Device ID already exists in the device's claims.
+	deviceConnection, _, err := defaultDialer.DialDevice(string(spoofedID), connectURL, nil)
+	require.NoError(err)
+
+	defer assert.Nil(deviceConnection.Close())
+
+	connectWait.Add(1)
+	connectWait.Wait()
+	close(connections)
+	assert.Equal(1, len(connections))
+
+	select {
+	case d := <-connections:
+		assert.NotEqual(d.ID(), spoofedID)
+		assert.Equal(d.ID(), realID)
+	case <-time.After(time.Millisecond):
+		assert.Fail("The connect listener should have returned a device")
+	}
+}
+
+func testManagerConnectDeviceIDFromHeader(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	id := ID("mac:1800deadbeef")
+	connections := make(chan *device, 1)
+	connectWait := new(sync.WaitGroup)
+	_, server, connectURL := startWebsocketServerWithRequestContext(
+		&Options{
+			Logger: zap.NewNop(),
+			Listeners: []Listener{
+				func(event *Event) {
+					if event.Type == Connect {
+						assert.NoError(event.Error)
+						d := event.Device.(*device)
+						defer connectWait.Done()
+						select {
+						case connections <- d:
+						default:
+							assert.Fail("The connect listener should not block")
+						}
+					}
+				},
+			},
+		},
+		// Device ID supplied via request header.
+		WithID(context.Background(), id))
+
+	defer server.Close()
+
+	// A spoofed ID will be supplied as a header but it should not be used since a Device ID already exists in its claims.
+	deviceConnection, _, err := defaultDialer.DialDevice(string(id), connectURL, nil)
+	require.NoError(err)
+
+	defer assert.Nil(deviceConnection.Close())
+
+	connectWait.Add(1)
+	connectWait.Wait()
+	close(connections)
+	assert.Equal(1, len(connections))
+	select {
+	case d := <-connections:
+		assert.Equal(d.ID(), id)
+	case <-time.After(time.Millisecond):
+		assert.Fail("The connect listener should have returned a device")
+	}
 }
 
 func testManagerConnectVisit(t *testing.T) {
@@ -396,6 +546,9 @@ func TestManager(t *testing.T) {
 		t.Run("UpgradeError", testManagerConnectUpgradeError)
 		t.Run("Visit", testManagerConnectVisit)
 		t.Run("IncludesConvey", testManagerConnectIncludesConvey)
+		t.Run("ConnectDeviceIDFromClaimsError", testManagerConnectDeviceIDFromClaimsError)
+		t.Run("ConnectDeviceIDFromClaims", testManagerConnectDeviceIDFromClaims)
+		t.Run("ConnectDeviceIDFromHeader", testManagerConnectDeviceIDFromHeader)
 	})
 
 	t.Run("Route", func(t *testing.T) {

--- a/device/metadata.go
+++ b/device/metadata.go
@@ -22,6 +22,7 @@ const (
 	PartnerIDClaimKey = "partner-id"
 	TrustClaimKey     = "trust"
 	AccountIDClaimKey = "accountID"
+	DeviceIDClaimKey  = "device-id"
 )
 
 // Default values
@@ -128,6 +129,17 @@ func (m *Metadata) AccountIDClaim() string {
 	accountID, _ := m.Claims()[AccountIDClaimKey].(string)
 
 	return accountID
+}
+
+// DeviceIDClaim returns the device id.
+// If no claim is found, the value defaults to an empty string.
+func (m *Metadata) DeviceIDClaim() (ID, error) {
+	id, _ := m.Claims()[DeviceIDClaimKey].(string)
+	if len(id) == 0 {
+		return "", nil
+	}
+
+	return ParseID(id)
 }
 
 func (m *Metadata) loadData() (data map[string]interface{}) {

--- a/device/metadata_test.go
+++ b/device/metadata_test.go
@@ -44,6 +44,7 @@ claims:
 	}
 	v.UnmarshalKey("claims", &claims)
 	claims[AccountIDClaimKey] = "0123456789"
+	claims[DeviceIDClaimKey] = "mac:1800deadbeef"
 }
 
 func TestDeviceMetadataDefaultValues(t *testing.T) {
@@ -55,6 +56,7 @@ func TestDeviceMetadataDefaultValues(t *testing.T) {
 	assert.Equal(UnknownPartner, m.PartnerIDClaim())
 	assert.Zero(m.TrustClaim())
 	assert.Zero(m.AccountIDClaim())
+	assert.Zero(m.DeviceIDClaim())
 	assert.Nil(m.Load("not-exists"))
 }
 
@@ -68,7 +70,9 @@ func TestDeviceMetadataInitClaims(t *testing.T) {
 	assert.Equal("comcast", m.PartnerIDClaim())
 	assert.Equal(100, m.TrustClaim())
 	assert.Equal("0123456789", m.AccountIDClaim())
-
+	id, err := m.DeviceIDClaim()
+	assert.NoError(err)
+	assert.Equal(ID(claims[DeviceIDClaimKey].(string)), id)
 	// test defensive copy
 	inputClaims[TrustClaimKey] = 200
 	assert.NotEqual(inputClaims, m.Claims())


### PR DESCRIPTION
device id is used to manage devices in talaria, using the device id from themis' JWT claims will ensure future device identity hardening (i.e. mac provided via device cert) will be inherited by talaria by default